### PR TITLE
Panopticon registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'json'
 gem 'unicorn'
 gem 'rake'
 gem 'multi_json', '1.8.4'
+gem 'gds-api-adapters', '8.4.1'
 
 group :development do
   gem 'mr-sparkle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
+    PriorityQueue (0.1.2)
     builder (3.1.4)
     cucumber (1.3.10)
       builder (>= 2.1.2)
@@ -11,14 +12,24 @@ GEM
       multi_test (>= 0.0.2)
     diff-lcs (1.2.5)
     ffi (1.9.3)
+    gds-api-adapters (8.4.1)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rest-client (~> 1.6.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     json (1.8.1)
     kgio (2.8.1)
+    link_header (0.0.8)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
+    mime-types (2.1)
     mr-sparkle (0.3.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
@@ -26,6 +37,8 @@ GEM
       unicorn (>= 4.5)
     multi_json (1.8.4)
     multi_test (0.0.3)
+    null_logger (0.0.1)
+    plek (1.7.0)
     rack (1.5.2)
     rack-protection (1.5.2)
       rack
@@ -38,6 +51,8 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -61,6 +76,7 @@ PLATFORMS
 
 DEPENDENCIES
   cucumber (= 1.3.10)
+  gds-api-adapters (= 8.4.1)
   json
   mr-sparkle
   multi_json (= 1.8.4)

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
 require 'cucumber/rake/task'
+require 'rspec/core/rake_task'
 
 Cucumber::Rake::Task.new(:cucumber, 'Run all features') do |t|
   t.fork = true # You may get faster startup if you set this to false
   t.cucumber_opts = 'features --format pretty'
 end
 
-task :default => :cucumber
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => [:spec, :cucumber]

--- a/features/panopticon_registration.feature
+++ b/features/panopticon_registration.feature
@@ -1,0 +1,9 @@
+Feature: Registration with panopticon
+  As a developer
+  I want to be able to register all finders with panopticon
+  So that they appear on the main GOV.UK domain
+
+@stub_panopticon_registerer
+Scenario:
+  When I run the panopticon:register rake task
+  Then the CMA Case finder is registered with panopticon

--- a/features/step_definitions/panopticon_registration_steps.rb
+++ b/features/step_definitions/panopticon_registration_steps.rb
@@ -1,0 +1,11 @@
+When(/^I run the panopticon:register rake task$/) do
+  require "rake"
+  @rake = Rake::Application.new
+  Rake.application = @rake
+  Rake.application.rake_require "tasks/panopticon"
+  @rake['panopticon:register'].invoke
+end
+
+Then(/^the CMA Case finder is registered with panopticon$/) do
+  expect(PanopticonRegisterer).to have_received(:register)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift(File.expand_path("../../", File.dirname(__FILE__)))
+$LOAD_PATH.unshift(File.expand_path("../../lib/", File.dirname(__FILE__)))
 
 require "rack/test"
 require "finder_api"

--- a/features/support/mocks.rb
+++ b/features/support/mocks.rb
@@ -1,0 +1,1 @@
+require 'cucumber/rspec/doubles'

--- a/features/support/panopticon.rb
+++ b/features/support/panopticon.rb
@@ -1,0 +1,6 @@
+
+Before('@stub_panopticon_registerer') do
+  require 'panopticon_registerer'
+
+  allow(PanopticonRegisterer).to receive(:register)
+end

--- a/finder_api.rb
+++ b/finder_api.rb
@@ -6,7 +6,7 @@ require 'config/logging'
 class FinderApi < Sinatra::Application
 
   get '/:slug.json' do |slug|
-    File.read(File.expand_path("schemas/#{slug}.json", File.dirname(__FILE__)))
+    MultiJson.dump(SchemaRegistry.new.get(slug))
   end
 
   get '/finders/:slug/documents.json' do

--- a/lib/panopticon_registerer.rb
+++ b/lib/panopticon_registerer.rb
@@ -1,0 +1,9 @@
+require 'registerable_schema'
+require 'gds_api/panopticon'
+
+class PanopticonRegisterer
+  def self.register(schema)
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'finder-api', rendering_app: 'finder-frontend', kind: 'finder')
+    registerer.register(RegisterableSchema.new(schema))
+  end
+end

--- a/lib/registerable_schema.rb
+++ b/lib/registerable_schema.rb
@@ -1,0 +1,25 @@
+class RegisterableSchema
+  def initialize(schema)
+    @schema = schema
+  end
+
+  def slug
+    @schema['slug']
+  end
+
+  def name
+    @schema['name']
+  end
+
+  def description
+    ""
+  end
+
+  def state
+    "live"
+  end
+
+  def paths
+    "/#{slug}"
+  end
+end

--- a/lib/schema_registry.rb
+++ b/lib/schema_registry.rb
@@ -1,0 +1,18 @@
+require 'multi_json'
+
+class SchemaRegistry
+  def initialize(schema_path = nil)
+    @schema_path = schema_path || File.expand_path("../schemas", File.dirname(__FILE__))
+  end
+
+  def all
+    Dir["#{@schema_path}/*.json"].map.with_object({}) do |path, all_schemas|
+      filename = File.basename(path, '.json')
+      all_schemas[filename] = MultiJson.load(File.read(path))
+    end
+  end
+
+  def get(slug)
+    all.fetch(slug, nil)
+  end
+end

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -1,0 +1,10 @@
+namespace :panopticon do
+  task :register do
+    require 'schema_registry'
+    require 'panopticon_registerer'
+
+    SchemaRegistry.new.all.each do |slug, schema|
+      PanopticonRegisterer.register(schema)
+    end
+  end
+end

--- a/spec/fixtures/schemas/cma-cases.json
+++ b/spec/fixtures/schemas/cma-cases.json
@@ -1,0 +1,5 @@
+{
+  "slug": "cma-cases",
+  "name": "Competition and Markets Authority cases",
+  "document_noun": "case"
+}

--- a/spec/unit/panopticon_registerer_spec.rb
+++ b/spec/unit/panopticon_registerer_spec.rb
@@ -1,0 +1,18 @@
+require 'panopticon_registerer'
+
+describe PanopticonRegisterer do
+  describe '.register' do
+    it "uses GdsApi::Panopticon::Registerer to register the schema" do
+      mock_schema = double("schema")
+      mock_registerer = double("registerer")
+      mock_registerable_schema = double("registerable schema")
+      expect(GdsApi::Panopticon::Registerer).to receive(:new)
+        .with(owning_app: 'finder-api', rendering_app: 'finder-frontend', kind: 'finder')
+        .and_return(mock_registerer)
+      expect(RegisterableSchema).to receive(:new).with(mock_schema).and_return(mock_registerable_schema)
+      expect(mock_registerer).to receive(:register).with(mock_registerable_schema)
+
+      PanopticonRegisterer.register(mock_schema)
+    end
+  end
+end

--- a/spec/unit/registerable_schema_spec.rb
+++ b/spec/unit/registerable_schema_spec.rb
@@ -1,0 +1,20 @@
+require 'registerable_schema'
+
+describe RegisterableSchema do
+  let(:schema) {
+    {
+      "slug" => "cma-cases",
+      "name" => "Competition and Markets Authority cases"
+    }
+  }
+
+  let(:registerable) { RegisterableSchema.new(schema) }
+
+  it "presents a version of a schema appropriate for registration with panopticon" do
+    expect(registerable.slug).to eq schema['slug']
+    expect(registerable.name).to eq schema['name']
+    expect(registerable.description).to eq ""
+    expect(registerable.state).to eq "live"
+    expect(registerable.paths).to eq "/cma-cases"
+  end
+end

--- a/spec/unit/schema_registry_spec.rb
+++ b/spec/unit/schema_registry_spec.rb
@@ -1,0 +1,24 @@
+require 'schema_registry'
+require 'multi_json'
+
+describe SchemaRegistry do
+  let(:fixture_path) { File.dirname(__FILE__) + "/../fixtures/schemas/" }
+  let(:fixture_file_data) { MultiJson.load(File.read(fixture_path + "/cma-cases.json")) }
+  let(:schema_registry) { SchemaRegistry.new(fixture_path) }
+
+  describe "#all" do
+    it "loads all the schemas" do
+      expect(schema_registry.all).to eq({ "cma-cases" => fixture_file_data })
+    end
+  end
+
+  describe "#get" do
+    it "gets the schema by slug" do
+      expect(schema_registry.get('cma-cases')).to eq fixture_file_data
+    end
+
+    it "returns nil if no schema for that slug" do
+      expect(schema_registry.get('non-existent')).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
As a developer
I want to be able to register all finders with panopticon
So that they appear on the main GOV.UK domain

Adds a rake task to do this registration. The idea is to invoke this
rake task whenever the finders are deployed. The definition of finders
will be in json schemas contained within this app.
