### PR TITLE
Fix logstasher missing const errors

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,6 +7,7 @@ ensure_load_path_has(app_path)
 ensure_load_path_has(app_path + "/lib")
 
 if ENV['RACK_ENV'] == 'production'
+  require "rack/logstasher"
   use Rack::Logstasher::Logger,
     Logger.new("log/production.json.log"),
     extra_request_headers: { "GOVUK-Request-Id" => "govuk_request_id", "x-varnish" => "varnish_id" }


### PR DESCRIPTION
I think this block was copy/pasted from content-api, but content-api does a `Bundler.require` which this app doesn't.
