### PR TITLE
Move schema JSON endpoint to match other endpoints.

### DIFF
--- a/features/step_definitions/schema_steps.rb
+++ b/features/step_definitions/schema_steps.rb
@@ -1,5 +1,5 @@
 When(/^I request the "(.*?)" schema$/) do |slug|
-  @response = get("/#{slug}.json")
+  @response = get("/finders/#{slug}/schema.json")
 end
 
 Then(/^I receive a JSON document describing "(.*?)"$/) do |slug|

--- a/finder_api.rb
+++ b/finder_api.rb
@@ -12,7 +12,7 @@ require 'adapters/sinatra_adapter'
 
 class FinderApi < Sinatra::Application
 
-  get '/:slug.json' do |slug|
+  get '/finders/:finder_type/schema.json' do |slug|
     schema = app.send(:schemas).fetch(slug)
     sinatra_adapter.success(schema.to_h)
   end


### PR DESCRIPTION
This will be used at first by the finder frontend, then also by the specialist publisher.
