### PR TITLE
Add stemming option to ElasticSearch index

### DIFF
--- a/features/get_filtered_cases.feature
+++ b/features/get_filtered_cases.feature
@@ -73,7 +73,7 @@ Feature: GET filtered cases
     When I GET "/finders/cma-cases/documents.json"
     Then I receive 11 documents
 
-  Scenario: Keyword search
+  Scenario: Keyword search with stemming
     Given there are registered documents
-    When I GET "/finders/cma-cases/documents.json?keywords=fuels"
+    When I GET "/finders/cma-cases/documents.json?keywords=fuel"
     Then I receive all documents with a body or summary containing the keywords

--- a/features/get_filtered_cases.feature
+++ b/features/get_filtered_cases.feature
@@ -73,6 +73,11 @@ Feature: GET filtered cases
     When I GET "/finders/cma-cases/documents.json"
     Then I receive 11 documents
 
+  Scenario: Keyword search for exact match
+    Given there are registered documents
+    When I GET "/finders/cma-cases/documents.json?keywords=fuels"
+    Then I receive all documents with a body or summary containing the keywords
+
   Scenario: Keyword search with stemming
     Given there are registered documents
     When I GET "/finders/cma-cases/documents.json?keywords=fuel"

--- a/lib/elastic_search_registerer.rb
+++ b/lib/elastic_search_registerer.rb
@@ -7,7 +7,7 @@ class ElasticSearchRegisterer
   end
 
   def store_map(mapping)
-    http_client.put(index_path)
+    http_client.put(index_path, index_settings)
     http_client.put(mapping_path(mapping), json_mapping(mapping))
   end
 
@@ -24,5 +24,27 @@ private
 
   def json_mapping(mapping)
     MultiJson.dump(mapping.to_h)
+  end
+
+  def index_settings
+    {
+      "settings" => {
+        "analysis" => {
+          "analyzer" => {
+            "default" => {
+              "type" => "custom",
+              "tokenizer" => "standard",
+              "filter" => %w(standard lowercase stemmer_english),
+            },
+          },
+          "filter" => {
+            "stemmer_english" => {
+              "type" => "stemmer",
+              "name" => "english",
+            },
+          }
+        }
+      }
+    }
   end
 end

--- a/spec/unit/elastic_search_registerer_spec.rb
+++ b/spec/unit/elastic_search_registerer_spec.rb
@@ -24,7 +24,8 @@ describe ElasticSearchRegisterer do
 
     it "creates the index" do
       registerer.store_map(mapping)
-      expect(http_client).to have_received(:put).with(index_path)
+      expect(http_client).to have_received(:put)
+        .with(index_path, hash_including("settings"))
     end
 
     it "sends the json-encoded mapping to ES" do


### PR DESCRIPTION
Allows search for "fuel" to work when document contains "fuels"
