### PR TITLE
Delete cases

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -38,6 +38,13 @@ class Application
     ).call
   end
 
+  def delete_case(context)
+    DeleteCase.new(
+      cases_repository,
+      context,
+    ).call
+  end
+
   def initialize_persistence(context = NullAdapter.new)
     RegisterSchemaWithElasticSearch.new(
       schema_registerer,

--- a/features/delete_case.feature
+++ b/features/delete_case.feature
@@ -1,0 +1,9 @@
+Feature: DELETE case
+  As an API client
+  I want to be able to delete cases from the finder
+  So that it is no longer publicly accessible
+
+  Scenario: Delete existing case
+    Given there are registered documents
+    When I DELETE "/finders/cma-cases/healthcorp-druginc-merger-inquiry"
+    Then the document is no longer available

--- a/features/delete_case_steps.rb
+++ b/features/delete_case_steps.rb
@@ -1,0 +1,13 @@
+When(/^I DELETE "(.*?)"$/) do |path|
+  response = delete(path)
+  force_elastic_search_consistency
+
+  expect(response.status).to eq(200)
+end
+
+Then(/^the document is no longer available$/) do
+  response = get("finders/cma-cases/documents.json?case_type=mergers")
+  parsed_response = JSON.load(response.body)
+
+  expect(parsed_response.fetch("results")).to be_empty
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,39 +14,13 @@ require "rack/test"
 require "finder_api"
 require "features/support/schema_helpers"
 require "features/support/case_helpers"
+require "features/support/persistence_helpers"
 
 module SinatraTestIntegration
   include Rack::Test::Methods
 
   def app
     FinderApi.new
-  end
-end
-
-
-module PersistenceHelpers
-  extend self
-
-  def elastic_search_base_uri
-    ENV['ELASTIC_SEARCH_BASE_URI']
-  end
-
-  def elastic_search_namespace
-    ENV['ELASTIC_SEARCH_NAMESPACE']
-  end
-
-  def clear_elastic_search
-    output = `curl -XDELETE '#{elastic_search_base_uri}/#{elastic_search_namespace}' 2>&1`
-    raise output unless $?.success?
-  end
-
-  def force_elastic_search_consistency
-    output = `curl -XPOST '#{elastic_search_base_uri}/#{elastic_search_namespace}/_flush' 2>&1`
-    raise output unless $?.success?
-  end
-
-  def force_elastic_search_consistency
-   system("curl -XPOST 'http://localhost:9200/finder-api-test/_flush'")
   end
 end
 

--- a/features/support/persistence_helpers.rb
+++ b/features/support/persistence_helpers.rb
@@ -1,0 +1,26 @@
+module PersistenceHelpers
+  extend self
+
+  def elastic_search_base_uri
+    ENV['ELASTIC_SEARCH_BASE_URI']
+  end
+
+  def elastic_search_namespace
+    ENV['ELASTIC_SEARCH_NAMESPACE']
+  end
+
+  def clear_elastic_search
+    output = `curl -XDELETE '#{elastic_search_base_uri}/#{elastic_search_namespace}' 2>&1`
+    raise output unless $?.success?
+  end
+
+  def force_elastic_search_consistency
+    output = `curl -XPOST '#{elastic_search_base_uri}/#{elastic_search_namespace}/_flush' 2>&1`
+    raise output unless $?.success?
+  end
+
+  def force_elastic_search_consistency
+   system("curl -XPOST 'http://localhost:9200/finder-api-test/_flush'")
+  end
+end
+

--- a/finder_api.rb
+++ b/finder_api.rb
@@ -25,6 +25,10 @@ class FinderApi < Sinatra::Application
     app.register_case(sinatra_adapter)
   end
 
+  delete '/finders/:finder_type/:slug' do
+    app.delete_case(sinatra_adapter)
+  end
+
   def initialize(*args, &block)
     super
 

--- a/lib/elastic_search_repository.rb
+++ b/lib/elastic_search_repository.rb
@@ -13,7 +13,7 @@ class ElasticSearchRepository
     query = query_builder.call(criteria)
 
     # TODO: refactor into an adapter
-    post("/#{namespace}/#{finder_type}/_search?size=1000", query)
+    http_client.post("/#{namespace}/#{finder_type}/_search?size=1000", query)
       .body
       .fetch("hits")
       .fetch("hits")
@@ -21,12 +21,14 @@ class ElasticSearchRepository
   end
 
   def store(slug, document_data)
-    put("/#{namespace}/#{slug}", document_data)
+    http_client.put("/#{namespace}/#{slug}", document_data)
+  end
+
+  def delete(slug)
+    http_client.delete("/#{namespace}/#{slug}")
   end
 
   private
 
   attr_reader :http_client, :query_builder, :namespace
-
-  def_delegators :http_client, :post, :put
 end

--- a/services/delete_case.rb
+++ b/services/delete_case.rb
@@ -1,0 +1,28 @@
+class DeleteCase
+  def initialize(cases_repository, context)
+    @cases_repository = cases_repository
+    @context = context
+  end
+
+  def call
+    cases_repository.delete(storage_id)
+
+    context.success
+  end
+
+  private
+
+  attr_reader :cases_repository, :context
+
+  def storage_id
+    [finder_type, document_slug].join("/")
+  end
+
+  def document_slug
+    context.params.fetch("slug")
+  end
+
+  def finder_type
+    context.params.fetch("finder_type")
+  end
+end

--- a/spec/elastic_search_repository_spec.rb
+++ b/spec/elastic_search_repository_spec.rb
@@ -11,7 +11,7 @@ describe ElasticSearchRepository do
     )
   }
 
-  let(:http_client)      { double(:http_client, put: nil, post: nil) }
+  let(:http_client)      { double(:http_client, put: nil, post: nil, delete: nil) }
   let(:namespace)        { "test-namespace" }
   let(:query_builder)    { double(:query_builder) }
 
@@ -69,4 +69,16 @@ describe ElasticSearchRepository do
         .with("/#{namespace}/#{slug}", document_data)
     end
   end
+
+  describe "#delete" do
+    let(:slug) { "document_finder_type/document_title_slug" }
+
+    it "DELETEs the document data to the ES endpoint" do
+      repo.delete(slug)
+
+      expect(http_client).to have_received(:delete)
+        .with("/#{namespace}/#{slug}")
+    end
+  end
+
 end


### PR DESCRIPTION
When a document is withdrawn from Specialist Publisher it needs to delete it from the Finder API index
