### PR TITLE
Fix for cases not being sorted by updated_at

### DIFF
--- a/features/get_filtered_cases.feature
+++ b/features/get_filtered_cases.feature
@@ -16,6 +16,7 @@ Feature: GET filtered cases
             "opened_date": "2005-12-30",
             "closed_date": "2006-03-01",
             "summary": "Inquiry into the Healthcorp / Druginc merger",
+            "updated_at": "2014-04-15",
 
             "market_sector": {
               "value": "pharmaceuticals",

--- a/features/put_case.feature
+++ b/features/put_case.feature
@@ -17,7 +17,8 @@ Feature: PUT new cases
         "case_type": "mergers",
         "case_state": "closed",
         "market_sector": "pharmaceuticals",
-        "outcome_type": "ca98-infringement-chapter-i"
+        "outcome_type": "ca98-infringement-chapter-i",
+        "updated_at": "2014-04-15"
       }
     """
     Then I receive an empty 200 response

--- a/features/step_definitions/get_filtered_cases_steps.rb
+++ b/features/step_definitions/get_filtered_cases_steps.rb
@@ -17,6 +17,7 @@ Given(/^there are (\d+) registered documents$/) do |number_of_docs_to_create|
       "case_type" => "ca98-and-civil-cartels",
       "case_state" => "open",
       "market_sector" => "distribution-and-service-industries",
+      "updated_at" => "2014-04-15",
     }))
   end
 

--- a/features/support/case_helpers.rb
+++ b/features/support/case_helpers.rb
@@ -10,6 +10,7 @@ module CaseHelpers
       "case_type" => "ca98-and-civil-cartels",
       "case_state" => "open",
       "market_sector" => "distribution-and-service-industries",
+      "updated_at" => "2014-04-15",
     }
   end
 
@@ -24,7 +25,8 @@ module CaseHelpers
       "case_type" => "mergers",
       "case_state" => "closed",
       "market_sector" => "pharmaceuticals",
-      "outcome_type" => "mergers-phase-1-found-not-to-qualify"
+      "outcome_type" => "mergers-phase-1-found-not-to-qualify",
+      "updated_at" => "2014-04-15",
     }
   end
 
@@ -40,6 +42,7 @@ module CaseHelpers
       "case_state" => "closed",
       "market_sector" => "distribution-and-service-industries",
       "outcome_type" => "ca98-infringement-chapter-i",
+      "updated_at" => "2014-04-15",
     }
   end
 

--- a/lib/elastic_search_query.rb
+++ b/lib/elastic_search_query.rb
@@ -30,7 +30,11 @@ class ElasticSearchQuery
 
   def match_query
     if keywords.empty?
-      {}
+      {
+        sort: [
+          { updated_at: { order: :desc }}
+        ]
+      }
     else
       {
         query: {

--- a/spec/elastic_search_query_spec.rb
+++ b/spec/elastic_search_query_spec.rb
@@ -19,6 +19,13 @@ describe ElasticSearchQuery do
 
       let(:es_single_term_query) {
         {
+          sort: [
+            {
+              updated_at: {
+                order: :desc
+              }
+            }
+          ],
           filter: {
             and: {
               filters: [
@@ -106,6 +113,13 @@ describe ElasticSearchQuery do
 
       let(:es_multiple_range_query) {
         {
+          sort: [
+            {
+              updated_at: {
+                order: :desc
+              }
+            }
+          ],
           filter: {
             and: {
               filters: [


### PR DESCRIPTION
Previously when no keyword was applied, cases were in a random order. Now, cases are sorted by updated at unless there is a keyword.

Relates to https://trello.com/c/FXFzVQs5/67-bug-cases-not-in-last-updated-order-for-cma-finder
