### PR TITLE
Configure Faraday to raise errors

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -88,6 +88,7 @@ class Application
     Faraday.new(:url => @elastic_search_base_uri) do |conn|
       conn.response :json
       conn.request :json
+      conn.use Faraday::Response::RaiseError
 
       conn.adapter Faraday.default_adapter
     end


### PR DESCRIPTION
This will prevent error swallowing when talking to Elastic Search
