### PR TITLE
Add aaib-reports.json schema

### DIFF
--- a/schemas/aaib-reports.json
+++ b/schemas/aaib-reports.json
@@ -1,0 +1,34 @@
+{
+  "slug": "aaib-reports",
+  "name": "Air Accident Investigation Branch reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "aircraft_category",
+      "name": "Aircraft category",
+      "type": "single-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
+        {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
+        {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
+        {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
+        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "single-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Annual safety reports", "value": "annual-safety-reports"},
+        {"label": "Correspondence investigations", "value": "correspondence-investigations"},
+        {"label": "Field investigations", "value": "field-investigations"},
+        {"label": "Foreign reports", "value": "foreign-reports"},
+        {"label": "Formal reports", "value": "formal-reports"},
+        {"label": "Special bulletins", "value": "special-bulletins"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
AAIB reports schema to finder api in order for other applications to use it. This will be required by specialist-frontend in order to build the correct labels for metadata attributes when displaying to the user.
