### PR TITLE
Add aaib-reports.json schema

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -46,7 +46,7 @@ class Application
   end
 
   def initialize_persistence(context = NullAdapter.new)
-    RegisterSchemaWithElasticSearch.new(
+    RegisterSchemasWithElasticSearch.new(
       schema_registerer,
       elastic_search_translator,
       schemas.values,

--- a/features/panopticon_registration.feature
+++ b/features/panopticon_registration.feature
@@ -6,4 +6,4 @@ Feature: Registration with panopticon
 @stub_panopticon_registerer
 Scenario:
   When I run the panopticon:register rake task
-  Then the CMA Case finder is registered with panopticon
+  Then the finders have been registered with panopticon

--- a/features/step_definitions/panopticon_registration_steps.rb
+++ b/features/step_definitions/panopticon_registration_steps.rb
@@ -6,6 +6,6 @@ When(/^I run the panopticon:register rake task$/) do
   @rake['panopticon:register'].invoke
 end
 
-Then(/^the CMA Case finder is registered with panopticon$/) do
-  expect(PanopticonRegisterer).to have_received(:register)
+Then(/^the finders have been registered with panopticon$/) do
+  expect(PanopticonRegisterer).to have_received(:register).twice
 end

--- a/lib/elastic_search_registerer.rb
+++ b/lib/elastic_search_registerer.rb
@@ -7,8 +7,13 @@ class ElasticSearchRegisterer
   end
 
   def store_map(mapping)
-    http_client.put(index_path, index_settings)
     http_client.put(mapping_path(mapping), json_mapping(mapping))
+  rescue Faraday::Error::ClientError => e
+    fail e unless e.response.fetch(:body).match(/already exists/i)
+  end
+
+  def create_index
+    http_client.put(index_path, index_settings)
   rescue Faraday::Error::ClientError => e
     fail e unless e.response.fetch(:body).match(/already exists/i)
   end

--- a/schemas/aaib-reports.json
+++ b/schemas/aaib-reports.json
@@ -1,0 +1,34 @@
+{
+  "slug": "aaib-reports",
+  "name": "Air Accident Investigation Branch reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "aircraft_category",
+      "name": "Aircraft category",
+      "type": "multi-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
+        {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
+        {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
+        {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
+        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "multi-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Annual safety reports", "value": "annual-safety-reports"},
+        {"label": "Correspondence investigations", "value": "correspondence-investigations"},
+        {"label": "Field investigations", "value": "field-investigations"},
+        {"label": "Foreign reports", "value": "foreign-reports"},
+        {"label": "Formal reports", "value": "formal-reports"},
+        {"label": "Special bulletins", "value": "special-bulletins"}
+      ]
+    }
+  ]
+}

--- a/services/register_schemas_with_elastic_search.rb
+++ b/services/register_schemas_with_elastic_search.rb
@@ -1,4 +1,4 @@
-class RegisterSchemaWithElasticSearch
+class RegisterSchemasWithElasticSearch
   def initialize(registerer, elastic_search_translator, schemas, context)
     @registerer = registerer
     @elastic_search_translator = elastic_search_translator
@@ -7,11 +7,12 @@ class RegisterSchemaWithElasticSearch
   end
 
   def call
+    create_index
     schemas.each do |schema|
       register_schema(schema)
     end
 
-    context.success(message: "Scheamas successfully registered")
+    context.success(message: "Schemas successfully registered")
   end
 
   private
@@ -22,6 +23,10 @@ class RegisterSchemaWithElasticSearch
     :schemas,
     :context
   )
+
+  def create_index
+    registerer.create_index
+  end
 
   def register_schema(schema)
     registerer.store_map(translate_schema_to_mapping(schema))

--- a/spec/unit/elastic_search_registerer_spec.rb
+++ b/spec/unit/elastic_search_registerer_spec.rb
@@ -16,21 +16,23 @@ describe ElasticSearchRegisterer do
       finder_slug: 'cma-cases'
     )
   }
+  let(:index_path) { "/#{namespace}" }
 
   describe "#store(elastic_search_mapping)" do
-    let(:index_path) { "/#{namespace}" }
     let(:mapping_path) { "#{index_path}/cma-cases/_mapping" }
     let(:json_mapping) { MultiJson.dump(mapping_hash) }
-
-    it "creates the index" do
-      registerer.store_map(mapping)
-      expect(http_client).to have_received(:put)
-        .with(index_path, hash_including("settings"))
-    end
 
     it "sends the json-encoded mapping to ES" do
       registerer.store_map(mapping)
       expect(http_client).to have_received(:put).with(mapping_path, json_mapping)
+    end
+  end
+
+  describe "#create_index" do
+    it "creates the index" do
+      registerer.create_index
+      expect(http_client).to have_received(:put)
+        .with(index_path, hash_including("settings"))
     end
   end
 end


### PR DESCRIPTION
AAIB reports schema to finder api in order for other applications to use it. This will be required by specialist-frontend in order to build the correct labels for metadata attributes when displaying to the user.
