### PR TITLE
Default ENV for panopticon:register rake task

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -3,6 +3,7 @@ namespace :panopticon do
   task :register do
     require "application"
     require 'panopticon_registerer'
+    require "config/initializers/elasticsearch.rb"
     require 'config/initializers/panopticon_api_credentials.rb'
 
     app = Application.new(ENV)


### PR DESCRIPTION
Load the initializer that defaults the `ELASTIC_SEARCH_BASE_URI` and `ELASTIC_SEARCH_NAMESPACE` environment variables so we don't need to provide them when running the rake task.
