### PR TITLE
Rename idf_sector to development_sector

### DIFF
--- a/schemas/international-development-funding.json
+++ b/schemas/international-development-funding.json
@@ -137,7 +137,7 @@
       ]
     },
     {
-      "key": "idf_sector",
+      "key": "development_sector",
       "name": "Sector",
       "type": "multi-select",
       "include_blank": false,


### PR DESCRIPTION
We don't want to expose the term idf_sector anywhere, so it needs to be changed to development_sector. [Ticket](https://trello.com/c/d1iL0wup/237-change-idf-sector-key-to-development-sector-1).
