### PR TITLE
Require better_errors only in development

### DIFF
--- a/config/initializers/better_errors.rb
+++ b/config/initializers/better_errors.rb
@@ -1,6 +1,6 @@
-require "better_errors"
-
 configure :development do
+  require "better_errors"
+
   use BetterErrors::Middleware
   BetterErrors.application_root = __dir__
 end


### PR DESCRIPTION
The better_errors gem is not available in other environments so only require it in development mode.
