### PR TITLE
Add some default properties to schema mappings

### DIFF
--- a/lib/elastic_search_mapping.rb
+++ b/lib/elastic_search_mapping.rb
@@ -24,6 +24,10 @@ private
   end
 
   def properties
+    default_properties.merge(facet_properties)
+  end
+
+  def facet_properties
     facets.reduce({}) do |hash, facet|
       hash.merge(facet.fetch("key") => {
         'type' => 'string',
@@ -34,5 +38,26 @@ private
 
   def facets
     @schema.fetch("facets")
+  end
+
+  def default_properties
+    {
+      "updated_at" => {
+        "type" => "date",
+        "index" => "not_analyzed",
+      },
+      "title" => {
+        "type" => "string",
+        "index" => "analyzed",
+      },
+      "body" => {
+        "type" => "string",
+        "index" => "analyzed",
+      },
+      "summary" => {
+        "type" => "string",
+        "index" => "analyzed",
+      },
+    }
   end
 end

--- a/spec/unit/elastic_search_mapping_spec.rb
+++ b/spec/unit/elastic_search_mapping_spec.rb
@@ -10,27 +10,40 @@ describe ElasticSearchMapping do
     MultiJson.load(File.read("spec/fixtures/schemas/cma-cases.json"))
   }
 
-  let(:facets) {
+  let(:default_facets) {
+    %w(
+      title
+      summary
+      body
+      updated_at
+    )
+  }
+
+  let(:format_facets) {
     ["case_type", "case_state", "market_sector", "outcome_type"]
+  }
+
+  let(:all_facets) {
+    default_facets + format_facets
   }
 
   describe "#to_h" do
     it "returns a mapping containing all facets" do
       mapping_properties = mapping.to_h.fetch("cma-cases").fetch("properties")
 
-      expect(mapping_properties.keys).to match_array(facets)
+      expect(mapping_properties.keys).to match_array(all_facets)
     end
 
-    it "maps all facets to string type (until we know more about the schema)" do
-      mapping_properties = mapping.to_h.fetch("cma-cases").fetch("properties")
+    it "sets format-specific facets to string type" do
+      mapping_properties = mapping.to_h.fetch("cma-cases").fetch("properties").slice(format_facets)
 
       mapping_properties.each do |_, attributes|
         expect(attributes['type']).to eq('string')
       end
     end
 
-    it "sets everything to not_analyzed (as we have no body fields)"do
-      mapping_properties = mapping.to_h.fetch("cma-cases").fetch("properties")
+    it "sets format-specific facets to not_analyzed"do
+      mapping_properties = mapping.to_h.fetch("cma-cases").fetch("properties").slice(format_facets)
 
       mapping_properties.each do |_, attributes|
         expect(attributes['index']).to eq('not_analyzed')


### PR DESCRIPTION
Most importantly is the `updated_at` field, which is used to sort the
results if no keyword term is provided. Because this field doesn't exist
until the first entry has been added, the elasticsearch query causes an
error.
