### PR TITLE
Remove better_errors config require from rake task

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -5,7 +5,6 @@ namespace :panopticon do
     require 'panopticon_registerer'
     require "config/initializers/elasticsearch.rb"
     require 'config/initializers/panopticon_api_credentials.rb'
-    require 'config/initializers/better_errors.rb'
 
     app = Application.new(ENV)
 


### PR DESCRIPTION
The rake task doesn't load Sinatra so it doesn't have `configure`. Plus,
since this is a rake task to be run from the console, having an HTML
error page isn't actually very useful.
