### PR TITLE
Fix double and typo in date preposition

### DIFF
--- a/schemas/aaib-reports.json
+++ b/schemas/aaib-reports.json
@@ -37,7 +37,7 @@
       "key": "date_of_occurrence",
       "name": "Date of occurrence",
       "type": "multi-select",
-      "preposition": "and date of occurrence",
+      "preposition": "date of occurrence",
       "elasticsearch_config": {
         "type": "date"
       },


### PR DESCRIPTION
The date of occurrence preposition in the schema contains an 'and', which is not needed as it always comes last and is formed with to_sentence, adding the 'and' for us.
