### PR TITLE
Add schema for drug device alerts

### DIFF
--- a/schemas/drug-device-alerts.json
+++ b/schemas/drug-device-alerts.json
@@ -1,0 +1,49 @@
+{
+  "slug": "drug-device-alerts",
+  "name": "Alerts and recalls for drugs and medical devices",
+  "document_noun": "alert",
+  "facets": [
+    {
+      "key": "alert_type",
+      "name": "Alert type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "for",
+      "allowed_values": [
+        {"label": "Drugs", "value": "drugs"},
+        {"label": "Devices", "value": "devices"}
+      ]
+    },
+    {
+      "key": "medical_specialism",
+      "name": "Medical specialism",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "about",
+      "allowed_values": [
+        {"label": "Anaesthetics", "value": "anaesthetics" },
+        {"label": "Cardiology", "value": "cardiology" },
+        {"label": "Care home staff", "value": "care-home-staff" },
+        {"label": "Cosmetic surgery", "value": "cosmetic-surgery" },
+        {"label": "Critical care", "value": "critical-care" },
+        {"label": "Dentistry", "value": "dentistry" },
+        {"label": "General practice", "value": "general-practice" },
+        {"label": "General surgery", "value": "general-surgery" },
+        {"label": "Haematology and oncology", "value": "haematology-oncology" },
+        {"label": "Infection prevention", "value": "infection-prevention" },
+        {"label": "Obstetrics and gynaecology", "value": "obstetrics-gynaecology" },
+        {"label": "Ophthalmology", "value": "ophthalmology" },
+        {"label": "Orthopaedics", "value": "orthopaedics" },
+        {"label": "Paediatrics", "value": "paediatrics" },
+        {"label": "Pathology", "value": "pathology" },
+        {"label": "Pharmacy", "value": "pharmacy" },
+        {"label": "Physiotherapy and occupational therapy", "value": "physiotherapy-occupational-therapy" },
+        {"label": "Radiology", "value": "radiology" },
+        {"label": "Renal medicine", "value": "renal-medicine" },
+        {"label": "Theatre practitioners", "value": "theatre-practitioners" },
+        {"label": "Urology", "value": "urology" },
+        {"label": "Vascular and cardiac surgery", "value": "vascular-cardiac-surgery" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We should check that we want to actually use single-select here. After a discussion with @alicebartlett we decided single select currently requires no modification to go live (as multi select will require work to not collapse when using only 2 options) although we should consider the impact of using single selects on our finder endpoints.
