### PR TITLE
Rename alert types to include 'alert'

### DIFF
--- a/schemas/drug-device-alerts.json
+++ b/schemas/drug-device-alerts.json
@@ -10,8 +10,8 @@
       "include_blank": false,
       "preposition": "for",
       "allowed_values": [
-        {"label": "Drugs", "value": "drugs"},
-        {"label": "Devices", "value": "devices"}
+        {"label": "Drug Alert", "value": "drugs"},
+        {"label": "Medical Device Alert", "value": "devices"}
       ]
     },
     {


### PR DESCRIPTION
[Ticket](https://trello.com/c/vsK026Nw/310-alerts-finder-devices-should-be-medical-devices)
