### PR TITLE
Add sample panopticon API credentials for development

### DIFF
--- a/config/initializers/panopticon_api_credentials.rb
+++ b/config/initializers/panopticon_api_credentials.rb
@@ -1,0 +1,3 @@
+PANOPTICON_API_CREDENTIALS = {
+          bearer_token: "foo"
+}


### PR DESCRIPTION
Without the constant in existence the panopticon rake task can't be run in development mode/on the development VM (panopticon returns 401 Unauthorized because no bearer token is provided at all).

With the token in existence, no matter its content, panopticon operates correctly in development.
