### PR TITLE
Add signup route copy and url

### DIFF
--- a/lib/registerable_schema.rb
+++ b/lib/registerable_schema.rb
@@ -20,6 +20,6 @@ class RegisterableSchema
   end
 
   def paths
-    ["/#{slug}", "/#{slug}.json"]
+    ["/#{slug}", "/#{slug}.json", "/#{slug}/signup"]
   end
 end

--- a/schemas/cma-cases.json
+++ b/schemas/cma-cases.json
@@ -2,6 +2,8 @@
   "slug": "cma-cases",
   "name": "Competition and Markets Authority cases",
   "document_noun": "case",
+  "email_signup_copy": "You will be notified each time a new CMA case is published or an existing CMA case is updated.",
+  "email_signup_url": "#",
   "facets": [
     {
         "key": "case_type",

--- a/spec/unit/registerable_schema_spec.rb
+++ b/spec/unit/registerable_schema_spec.rb
@@ -15,6 +15,6 @@ describe RegisterableSchema do
     expect(registerable.title).to eq schema['name']
     expect(registerable.description).to eq ""
     expect(registerable.state).to eq "live"
-    expect(registerable.paths).to eq ["/cma-cases", "/cma-cases.json"]
+    expect(registerable.paths).to eq ["/cma-cases", "/cma-cases.json", "/cma-cases/signup"]
   end
 end


### PR DESCRIPTION
This registers a fixed route for each finder with panopticon for `/:finder_slug/signup` when the `rake panopticon:register` task is run.

In addition, it adds two extra attributes to the schema -- `email_signup_copy` and `email_signup_url` explained more in the [finder-frontend PR](https://github.com/alphagov/finder-frontend/pull/74)

TODO:
- [ ] Add copy for all other schema types, not just CMA cases.
