### PR TITLE
Add date filtering for AAIB reports

### DIFF
--- a/schemas/aaib-reports.json
+++ b/schemas/aaib-reports.json
@@ -32,6 +32,12 @@
         {"label": "Formal report", "value": "formal-report"},
         {"label": "Special bulletin", "value": "special-bulletin"}
       ]
+    },
+    {
+      "key": "date_of_occurrence",
+      "name": "Date of occurrence",
+      "type": "date",
+      "preposition": "occurred"
     }
   ]
 }


### PR DESCRIPTION
To allow users to filter by date on the AAIB Finder, we need to add a date facet to the schema.

Relies on https://github.com/alphagov/finder-frontend/pull/79 being merged first.
