### PR TITLE
Date filtering for CMA

### DIFF
--- a/schemas/cma-cases.json
+++ b/schemas/cma-cases.json
@@ -102,6 +102,13 @@
         {"label": "Consumer enforcement - undertakings", "value": "consumer-enforcement-undertakings"},
         {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"}
       ]
+    },
+
+    {
+      "key": "date_opened",
+      "name": "Opened",
+      "type": "date",
+      "preposition": "opened"
     }
   ]
 }


### PR DESCRIPTION
Add date facet for the date opened field on CMA cases.

Relies on https://github.com/alphagov/finder-frontend/pull/79 being merged first.
