### PR TITLE
Export to publishing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'json'
 gem 'unicorn'
 gem 'rake'
 gem 'multi_json', '1.8.4'
-gem 'gds-api-adapters', '8.4.1'
+gem 'gds-api-adapters', '14.9.0'
 gem 'faraday', '0.8.9'
 gem 'faraday_middleware', '0.9.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'faraday_middleware', '0.9.0'
 gem 'rack-logstasher', '0.0.3'
 
 group :development do
-  gem "better_errors"
-  gem "binding_of_caller"
   gem 'mr-sparkle'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,6 @@ GEM
   specs:
     PriorityQueue (0.1.2)
     awesome_print (1.2.0)
-    better_errors (1.1.0)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.1.4)
     byebug (2.7.0)
       columnize (~> 0.3)
@@ -20,10 +15,8 @@ GEM
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.0.2)
-    debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
-    erubis (2.7.0)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
@@ -104,8 +97,6 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  better_errors
-  binding_of_caller
   byebug
   cucumber (= 1.3.10)
   faraday (= 0.8.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,11 +22,12 @@ GEM
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
     ffi (1.9.3)
-    gds-api-adapters (8.4.1)
+    gds-api-adapters (14.9.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rack-cache
       rest-client (~> 1.6.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -41,7 +42,7 @@ GEM
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     method_source (0.8.2)
-    mime-types (2.1)
+    mime-types (1.25.1)
     mr-sparkle (0.3.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
@@ -51,12 +52,14 @@ GEM
     multi_test (0.0.3)
     multipart-post (1.2.0)
     null_logger (0.0.1)
-    plek (1.7.0)
+    plek (1.9.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
     rack (1.5.2)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-logstasher (0.0.3)
       logstash-event
       rack
@@ -71,8 +74,11 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rdoc (4.1.2)
+      json (~> 1.4)
+    rest-client (1.6.8)
+      mime-types (~> 1.16)
+      rdoc (>= 2.4.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -101,7 +107,7 @@ DEPENDENCIES
   cucumber (= 1.3.10)
   faraday (= 0.8.9)
   faraday_middleware (= 0.9.0)
-  gds-api-adapters (= 8.4.1)
+  gds-api-adapters (= 14.9.0)
   json
   mr-sparkle
   multi_json (= 1.8.4)

--- a/config/initializers/better_errors.rb
+++ b/config/initializers/better_errors.rb
@@ -1,6 +1,0 @@
-configure :development do
-  require "better_errors"
-
-  use BetterErrors::Middleware
-  BetterErrors.application_root = __dir__
-end

--- a/lib/publishing_api_publisher.rb
+++ b/lib/publishing_api_publisher.rb
@@ -1,0 +1,48 @@
+require "gds_api/publishing_api"
+require "presenters/content_item_presenter"
+require "presenters/finder_content_item_presenter"
+
+class PublishingApiPublisher
+  def initialize(schemae)
+    @schemae = schemae
+  end
+
+  def call
+    schemae.each do |metadata|
+      export_finder(metadata)
+    end
+  end
+
+private
+  attr_reader :schemae
+
+  def export_finder(metadata)
+    attrs = exportable_attributes(FinderContentItemPresenter.new(metadata))
+    publishing_api.put_content_item(attrs["base_path"], attrs)
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find("publishing-api"))
+  end
+
+  def exportable_attributes(item)
+    {
+      "base_path" => item.base_path,
+      "format" => item.format,
+      "content_id" => item.content_id,
+      "title" => item.title,
+      "description" => item.description,
+      "public_updated_at" => item.public_updated_at,
+      "update_type" => "major",
+      "publishing_app" => "finder-api",
+      "rendering_app" => item.rendering_app,
+      "routes" => item.routes,
+      "details" => {},
+      "links" => {
+        "organisations" => item.organisations,
+        "topics" => [],
+        "related" => item.related,
+      },
+    }
+  end
+end

--- a/lib/tasks/content_store.rake
+++ b/lib/tasks/content_store.rake
@@ -1,0 +1,15 @@
+namespace :content_store do
+  desc "Publish all Finders to the Content Store"
+  task :publish do
+    require "application"
+    require "publishing_api_publisher"
+
+    require "multi_json"
+
+    metadata = Dir.glob("metadata/**/*.json").map do |file_path|
+      MultiJson.load(File.read(file_path))
+    end
+
+    PublishingApiPublisher.new(metadata).call
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,15 @@
+namespace :publishing_api do
+  desc "Publish all Finders to the Publishing API"
+  task :publish do
+    require "application"
+    require "publishing_api_publisher"
+
+    require "multi_json"
+
+    metadata = Dir.glob("metadata/**/*.json").map do |file_path|
+      MultiJson.load(File.read(file_path))
+    end
+
+    PublishingApiPublisher.new(metadata).call
+  end
+end

--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -1,5 +1,7 @@
 {
+  "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "slug": "aaib-reports",
   "name": "Air Accidents Investigation Branch reports",
-  "signup_copy": "You'll get an email each time a report is updated or a new report is published."
+  "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"]
 }

--- a/metadata/cma-cases.json
+++ b/metadata/cma-cases.json
@@ -1,5 +1,7 @@
 {
+  "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "slug": "cma-cases",
   "name": "Competition and Markets Authority cases",
-  "signup_copy": "You'll get an email each time a case is updated or a new case is published."
+  "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
+  "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
 }

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -1,5 +1,8 @@
 {
+  "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
   "name": "Alerts and recalls for drugs and medical devices",
-  "signup_copy": "You'll get an email each time an alert is updated or a new alert is published."
+  "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
+  "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
+  "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]
 }

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -1,5 +1,8 @@
 {
+  "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
   "name": "Drug safety update",
-  "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines."
+  "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
+  "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
+  "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"]
 }

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -1,5 +1,7 @@
 {
+  "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
   "name": "International development funding",
-  "signup_copy": "You'll get an email each time a fund is updated or a new fund is published."
+  "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
+  "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
 }

--- a/presenters/content_item_presenter.rb
+++ b/presenters/content_item_presenter.rb
@@ -1,0 +1,27 @@
+require "time"
+
+class ContentItemPresenter < Struct.new(:metadata)
+  def need_ids
+    []
+  end
+
+  def public_updated_at
+    Time.new.utc.iso8601
+  end
+
+  def details
+    {}
+  end
+
+  def rendering_app
+    "finder-frontend"
+  end
+
+  def organisations
+    metadata["organisations"]
+  end
+
+  def update_type
+    "minor"
+  end
+end

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -1,0 +1,38 @@
+class FinderContentItemPresenter < ContentItemPresenter
+  def title
+    metadata["name"]
+  end
+
+  def content_id
+    metadata["content_id"]
+  end
+
+  def base_path
+    "/#{metadata["slug"]}"
+  end
+
+  def description
+    ""
+  end
+
+  def format
+    "finder"
+  end
+
+  def related
+    metadata.fetch("related", [])
+  end
+
+  def routes
+    [
+      {
+        path: base_path,
+        type: "exact",
+      },
+      {
+        path: "#{base_path}.json",
+        type: "exact",
+      }
+    ]
+  end
+end

--- a/spec/unit/publishing_api_publisher_spec.rb
+++ b/spec/unit/publishing_api_publisher_spec.rb
@@ -1,0 +1,22 @@
+require "publishing_api_publisher"
+
+describe PublishingApiPublisher do
+  describe '.call' do
+    it "uses GdsApi::PublishingApi to publish the Finders" do
+      publishing_api = double("publishing-api")
+
+      metadata = [
+        {"slug" => "first-finder", "name" => "first finder"},
+        {"slug" => "second-finder", "name" => "second finder"},
+      ]
+
+      expect(GdsApi::PublishingApi).to receive(:new)
+        .with(Plek.new.find("publishing-api"))
+        .and_return(publishing_api)
+
+      expect(publishing_api).to receive(:put_content_item).twice
+
+      PublishingApiPublisher.new(metadata).call
+    end
+  end
+end


### PR DESCRIPTION
With the move of GOV.UK to use the Content Store, this PR contains commits which allow us to now publish Finders to the PublishingAPI. It contains a `PublishingAPIPublisher` class which handles exporting the Finder and it's signup page, a `ContentItemPresenter` class which has 2 child classes for the Finder and the Signup page. It also contains a spec for the PublishingAPIPublisher and a rake task to trigger publishing.

This changes to the schema add `content_id` which is needed to publish to the content_store. This has been generated in the console as with such a small number of Finders we don't need to worry about generating them in the App. I've also added the organisations and related (if required) fields to tag the Finders with their Org and other, related content_items.

This PR also bumps gds-api-adapters to get the Publishing API removes `better_errors` as this is an API only App an we don't need it.
- [x] Update Metadata JSON with real Org ContentStore UUIDs
