### PR TITLE
Add email signup content items to finders

### DIFF
--- a/lib/publishing_api_publisher.rb
+++ b/lib/publishing_api_publisher.rb
@@ -1,6 +1,7 @@
 require "gds_api/publishing_api"
 require "presenters/content_item_presenter"
 require "presenters/finder_content_item_presenter"
+require "presenters/finder_signup_content_item_presenter"
 
 class PublishingApiPublisher
   def initialize(schemae)
@@ -10,6 +11,7 @@ class PublishingApiPublisher
   def call
     schemae.each do |metadata|
       export_finder(metadata)
+      export_signup(metadata) if metadata.has_key?("signup_content_id")
     end
   end
 
@@ -18,6 +20,14 @@ private
 
   def export_finder(metadata)
     attrs = exportable_attributes(FinderContentItemPresenter.new(metadata))
+    if metadata.has_key?("signup_content_id")
+      attrs["links"].merge!( { "finder_email_signup" => [metadata["signup_content_id"]] })
+    end
+    publishing_api.put_content_item(attrs["base_path"], attrs)
+  end
+
+  def export_signup(metadata)
+    attrs = exportable_attributes(FinderSignupContentItemPresenter.new(metadata))
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end
 

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -2,6 +2,7 @@
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
   "name": "Alerts and recalls for drugs and medical devices",
+  "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -2,6 +2,7 @@
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
   "name": "Drug safety update",
+  "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"]

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -2,6 +2,7 @@
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
   "name": "International development funding",
+  "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
 }

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -1,0 +1,34 @@
+class FinderSignupContentItemPresenter < ContentItemPresenter
+  def title
+    "#{metadata["name"]} email alert subscription"
+  end
+
+  def content_id
+    metadata["signup_content_id"]
+  end
+
+  def base_path
+    "/#{metadata["slug"]}/email-signup"
+  end
+
+  def description
+    metadata["signup_copy"]
+  end
+
+  def format
+    "finder_email_signup"
+  end
+
+  def related
+    [metadata["content_id"]]
+  end
+
+  def routes
+    [
+      {
+        path: base_path,
+        type: "exact",
+      }
+    ]
+  end
+end


### PR DESCRIPTION
Linking email alert signup pages from Finder so Users can start the process to signup for emails. This commit adds the link if a content id of the email signup page is in the metadata hash.

This relies on https://github.com/alphagov/finder-api/pull/64 being merged first.
