### PR TITLE
Add published at to DSU schema

### DIFF
--- a/schemas/drug-safety-update.json
+++ b/schemas/drug-safety-update.json
@@ -33,6 +33,13 @@
         {"label": "Rheumatology", "value": "rheumatology"},
         {"label": "Urology and nephrology", "value": "urology-nephrology"}
       ]
+    },
+
+    {
+      "key": "published_date",
+      "name": "Published",
+      "type": "date",
+      "preposition": "published"
     }
   ]
 }

--- a/schemas/drug-safety-update.json
+++ b/schemas/drug-safety-update.json
@@ -36,7 +36,7 @@
     },
 
     {
-      "key": "published_date",
+      "key": "first_published_at",
       "name": "Published",
       "type": "date",
       "preposition": "published"


### PR DESCRIPTION
This pull request allows for facets to be generated on finder frontend for searching based on published_at date of a Drug Safety Update document

Trello ticket: https://trello.com/c/ZW0i6nya/362-add-first-published-date-to-the-dsu-finder-3-1
