### PR TITLE
Add schema and metadata for MAIB Reports

### DIFF
--- a/features/step_definitions/panopticon_registration_steps.rb
+++ b/features/step_definitions/panopticon_registration_steps.rb
@@ -9,6 +9,7 @@ end
 Then(/^the finders have been registered with panopticon$/) do
   slugs = %w(
     aaib-reports
+    maib-reports
     cma-cases
     international-development-funding
     drug-device-alerts

--- a/metadata/maib-reports.json
+++ b/metadata/maib-reports.json
@@ -1,0 +1,7 @@
+{
+  "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
+  "slug": "maib-reports",
+  "name": "Marine Accident Investigation Branch reports",
+  "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
+  "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"]
+}

--- a/schemas/maib-reports.json
+++ b/schemas/maib-reports.json
@@ -1,0 +1,39 @@
+{
+  "slug": "maib-reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "vessel_type",
+      "name": "Vessel type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Merchant vessel 100 gross tons or over", "value": "merchant-vessel-100-gross-tons-or-over"},
+        {"label": "Merchant vessel under 100 gross tons", "value": "merchant-vessel-under-100-gross-tons"},
+        {"label": "Fishing vessel", "value": "fishing-vessel"},
+        {"label": "Recreational craft - sail", "value": "recreational-craft-sail"},
+        {"label": "Recreational craft - power", "value": "recreational-craft-power"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Investigation reports", "value": "investigation-reports"},
+        {"label": "Safety bulletins", "value": "safety-bulletins"},
+        {"label": "Completed preliminary examinations", "value": "completed-preliminary-examinations"},
+        {"label": "Overseas reports", "value": "overseas-reports"}
+      ]
+    },
+    {
+      "key": "date_of_occurrence",
+      "name": "Date of occurrence",
+      "type": "date",
+      "preposition": "occurred"
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds MAIB report facet schema and metadata hash. [Ticket](https://trello.com/c/dp6yU20f/369-maib-finder-add-support-to-rummager-and-finder-api-for-maib-reports-1).
