### PR TITLE
Remove content signup IDs

### DIFF
--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -2,7 +2,6 @@
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
   "name": "Alerts and recalls for drugs and medical devices",
-  "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -2,7 +2,6 @@
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
   "name": "Drug safety update",
-  "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"]

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -2,7 +2,6 @@
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
   "name": "International development funding",
-  "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
 }


### PR DESCRIPTION
We don't want these added until after the agencies are OK for their signup pages to go live.
