### PR TITLE
Add email signup content ids

### DIFF
--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "slug": "aaib-reports",
   "name": "Air Accidents Investigation Branch reports",
+  "signup_content_id": "1ad5918c-19ff-4431-b20b-1bab890cd84b",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"]
 }

--- a/metadata/cma-cases.json
+++ b/metadata/cma-cases.json
@@ -2,6 +2,7 @@
   "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "slug": "cma-cases",
   "name": "Competition and Markets Authority cases",
+  "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
   "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
 }

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -2,6 +2,7 @@
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
   "name": "Alerts and recalls for drugs and medical devices",
+  "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -2,6 +2,7 @@
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
   "name": "Drug safety update",
+  "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["1e9c0ada-5f7e-43cc-a55f-cc32757edaa3"]

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -2,6 +2,7 @@
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
   "name": "International development funding",
+  "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
 }

--- a/metadata/maib-reports.json
+++ b/metadata/maib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "slug": "maib-reports",
   "name": "Marine Accident Investigation Branch reports",
+  "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"]
 }

--- a/metadata/raib-reports.json
+++ b/metadata/raib-reports.json
@@ -2,6 +2,7 @@
   "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "slug": "raib-reports",
   "name": "Rail Accident Investigation Branch reports",
+  "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
   "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"]
 }


### PR DESCRIPTION
As we want to expose these pages, we need signup_content_ids for each Finder. Content IDs are created by `SecureRandom.uuid` in Ruby and used as UUIDs in the ContentStore. They theoretically should never be duplicated.
