### PR TITLE
Explain Publishing API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Finder API has historically been used for two purposes:
 
 ##Running the application
 
+Start up the Publishing API to publish Finders to the Content Store:
+
+```
+bundle exec rake publishing_api:publish
+```
+Once the Finders are published, boot the App with:
+
 ```
 $ ./startup.sh
 ```


### PR DESCRIPTION
With the move of Finder Frontend to rely on ContentStore, we need to explain that you need to run a rake task to Publish them.
