### PR TITLE
Add report type to MAIB

### DIFF
--- a/schemas/maib-reports.json
+++ b/schemas/maib-reports.json
@@ -16,6 +16,19 @@
         {"label": "Recreational craft - power", "value": "recreational-craft-power"}
       ]
     },
+   {
+     "key": "report_type",
+     "name": "Report type",
+     "type": "multi-select",
+     "include_blank": false,
+     "preposition": "of type",
+     "allowed_values": [
+       {"label": "Investigation report", "value": "investigation-report"},
+       {"label": "Safety bulletin", "value": "safety-bulletin"},
+       {"label": "Completed preliminary examination", "value": "completed-preliminary-examination"},
+       {"label": "Overseas report", "value": "overseas-report"}
+     ]
+    },
     {
       "key": "date_of_occurrence",
       "name": "Date of occurrence",


### PR DESCRIPTION
With the current architecture, a report type facet is required to expand the metadata in specialist frontend.
