### PR TITLE
Add keyword search placeholder for MHRA finders

### DIFF
--- a/schemas/drug-device-alerts.json
+++ b/schemas/drug-device-alerts.json
@@ -1,6 +1,7 @@
 {
   "slug": "drug-device-alerts",
   "document_noun": "alert",
+  "keyword_search_placeholder": "eg Drug or device name",
   "facets": [
     {
       "key": "alert_type",

--- a/schemas/drug-safety-update.json
+++ b/schemas/drug-safety-update.json
@@ -1,6 +1,7 @@
 {
   "slug": "drug-safety-update",
   "document_noun": "update",
+  "keyword_search_placeholder": "eg Drug name",
   "facets": [
     {
       "key": "therapeutic_area",


### PR DESCRIPTION
MHRA users think update or alert title is a weird placeholder as they search for drug or device name.
