### PR TITLE
Placeholders should be lower case

### DIFF
--- a/schemas/drug-device-alerts.json
+++ b/schemas/drug-device-alerts.json
@@ -1,7 +1,7 @@
 {
   "slug": "drug-device-alerts",
   "document_noun": "alert",
-  "keyword_search_placeholder": "eg Drug or device name",
+  "keyword_search_placeholder": "eg drug or device name",
   "facets": [
     {
       "key": "alert_type",

--- a/schemas/drug-safety-update.json
+++ b/schemas/drug-safety-update.json
@@ -1,7 +1,7 @@
 {
   "slug": "drug-safety-update",
   "document_noun": "update",
-  "keyword_search_placeholder": "eg Drug name",
+  "keyword_search_placeholder": "eg drug name",
   "facets": [
     {
       "key": "therapeutic_area",


### PR DESCRIPTION
With the different placeholder for MHRA finders, the placeholder was incorrectly starting with an uppercase letter.
