### PR TITLE
Create topics on govdelivery for each format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'json'
 gem 'unicorn'
 gem 'rake'
 gem 'multi_json', '1.8.4'
-gem 'gds-api-adapters', '14.9.0'
+gem 'gds-api-adapters', '15.1.1'
 gem 'faraday', '0.8.9'
 gem 'faraday_middleware', '0.9.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
     ffi (1.9.3)
-    gds-api-adapters (14.9.0)
+    gds-api-adapters (15.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -107,7 +107,7 @@ DEPENDENCIES
   cucumber (= 1.3.10)
   faraday (= 0.8.9)
   faraday_middleware (= 0.9.0)
-  gds-api-adapters (= 14.9.0)
+  gds-api-adapters (= 15.1.1)
   json
   mr-sparkle
   multi_json (= 1.8.4)

--- a/lib/email_list_creator.rb
+++ b/lib/email_list_creator.rb
@@ -1,0 +1,61 @@
+require "plek"
+require "email_list_permutation_generator"
+require "gds_api/email_alert_api"
+
+class EmailListCreator
+  def initialize(metadata,
+                 permutation_generator_class: EmailListPermutationGenerator,
+                 api_client_class: GdsApi::EmailAlertApi)
+    @metadata = metadata
+    @permutation_generator_class = permutation_generator_class
+    @api_client_class = api_client_class
+  end
+
+  def call
+    if metadata["email_signup_choice"]
+      tag_hashes = permutation_generator.all_possible_tag_hashes
+      tag_hashes.each do |tag_hash|
+        api_client.find_or_create_subscriber_list(
+          {
+            "title" => list_title_for(tag_hash),
+            "tags" => tag_hash
+          }
+        )
+      end
+    else
+      api_client.find_or_create_subscriber_list(
+        {
+          "title" => metadata["name"],
+          "tags" => {
+            "format" => [metadata["slug"]],
+          }
+        }
+      )
+    end
+  end
+
+private
+  attr_reader :metadata, :permutation_generator_class, :api_client_class
+
+  def list_title_for(tag_hash)
+    key = email_signup_choice["key"]
+    key_name = email_signup_choice["key_name"]
+    selected_options = tag_hash[key].join(" or ")
+    "#{metadata["name"]} with #{key_name} #{selected_options}"
+  end
+
+  def permutation_generator
+    @generator ||= permutation_generator_class.new(
+      metadata["slug"],
+      email_signup_choice,
+    )
+  end
+
+  def api_client
+    @api_client ||= api_client_class.new(Plek.current.find("email-alert-api"))
+  end
+
+  def email_signup_choice
+    metadata["email_signup_choice"]
+  end
+end

--- a/lib/email_list_permutation_generator.rb
+++ b/lib/email_list_permutation_generator.rb
@@ -1,0 +1,27 @@
+
+class EmailListPermutationGenerator
+  def initialize(format, choices_hash)
+    @format = format
+    @choices_hash = choices_hash
+  end
+
+  def all_possible_tag_hashes
+    each_combination_of(choices_hash["choices"]).map do |combination|
+      {"format" => [format], choices_hash["key"] => combination}
+    end
+  end
+
+private
+  attr_reader :format, :choices_hash
+
+  # Creates a powerset for every possible combination of a set of options
+  def each_combination_of(value)
+    combinations = []
+    1.upto(value.size) do |n|
+      value.combination(n).each do |combination|
+        combinations << combination
+      end
+    end
+    combinations
+  end
+end

--- a/lib/publishing_api_publisher.rb
+++ b/lib/publishing_api_publisher.rb
@@ -47,7 +47,7 @@ private
       "publishing_app" => "finder-api",
       "rendering_app" => item.rendering_app,
       "routes" => item.routes,
-      "details" => {},
+      "details" => item.details,
       "links" => {
         "organisations" => item.organisations,
         "topics" => [],

--- a/lib/tasks/email_subscriptions.rake
+++ b/lib/tasks/email_subscriptions.rake
@@ -1,0 +1,13 @@
+namespace :email_subscriptions do
+  desc "Ensure there is a topic for every combination of email subscription on govdelivery"
+  task :register_subscriptions do
+    require "application"
+    require "email_list_creator"
+    require "multi_json"
+
+    Dir.glob("metadata/**/*.json").each do |file_path|
+      metadata = MultiJson.load(File.read(file_path))
+      EmailListCreator.new(metadata).call
+    end
+  end
+end

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -5,5 +5,10 @@
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
-  "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]
+  "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
+  "email_signup_choice": {
+    "choices": ["drug", "device"],
+    "key": "alert_type",
+    "key_name": "alert type"
+  }
 }

--- a/presenters/content_item_presenter.rb
+++ b/presenters/content_item_presenter.rb
@@ -9,8 +9,12 @@ class ContentItemPresenter < Struct.new(:metadata)
     Time.new.utc.iso8601
   end
 
+  # Put this into the details hash in the content store to let finder-frontendd render the checkboxes.
   def details
-    {}
+    {
+      tag_key: "alert_type",
+      tags: ["devices", "drugs"],
+    }
   end
 
   def rendering_app

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -23,6 +23,10 @@ class FinderContentItemPresenter < ContentItemPresenter
     metadata.fetch("related", [])
   end
 
+  def details
+    {}
+  end
+
   def routes
     [
       {

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -31,4 +31,10 @@ class FinderSignupContentItemPresenter < ContentItemPresenter
       }
     ]
   end
+
+  def details
+    {
+      "email_signup_choice" => metadata["email_signup_choice"],
+    }
+  end
 end

--- a/spec/fixtures/sample_metadata.json
+++ b/spec/fixtures/sample_metadata.json
@@ -1,0 +1,9 @@
+{
+  "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32758edaa3",
+  "slug": "finder-slug",
+  "name": "Test Format reports",
+  "signup_content_id": "a796ca43-051b-4960-9c99-f41bb8ef2266",
+  "signup_copy": "Signup copy info",
+  "organisations": ["241f72bd-9a4d-4f39-94d9-77235cadde8e"],
+  "related": ["606be505-4cf4-4f8c-8bfc-7bc4b63a7f47"]
+}

--- a/spec/fixtures/sample_metadata_with_signup_choices.json
+++ b/spec/fixtures/sample_metadata_with_signup_choices.json
@@ -1,0 +1,14 @@
+{
+  "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32758edaa3",
+  "slug": "finder-slug",
+  "name": "Test Format reports",
+  "signup_content_id": "a796ca43-051b-4960-9c99-f41bb8ef2266",
+  "signup_copy": "Signup copy info",
+  "organisations": ["241f72bd-9a4d-4f39-94d9-77235cadde8e"],
+  "related": ["606be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
+  "email_signup_choice": {
+    "choices": ["industrial", "commercial"],
+    "key_name": "zone",
+    "key": "zone"
+  }
+}

--- a/spec/lib/email_list_creator_spec.rb
+++ b/spec/lib/email_list_creator_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require "email_list_creator"
+require "multi_json"
+
+describe EmailListCreator do
+  let(:permutation_generator_class) { double(:permutation_generator_class, new: permutation_generator) }
+  let(:permutation_generator) { double(:permutation_generator, all_possible_tag_hashes: []) }
+
+  let(:email_alert_api_class) { double(:email_alert_api_class, new: email_alert_api_client) }
+  let(:email_alert_api_client) { double(:email_alert_api_client) }
+
+  subject(:list_creator) {
+    EmailListCreator.new(metadata,
+      permutation_generator_class: permutation_generator_class,
+      api_client_class: email_alert_api_class,
+    )
+  }
+
+  context "with signup choices" do
+    let(:metadata) { JSON.parse(File.read('spec/fixtures/sample_metadata_with_signup_choices.json')) }
+
+    it "requests the possible permutations" do
+      expect(permutation_generator_class).to receive(:new).with(
+        metadata["slug"],
+        metadata["email_signup_choice"],
+      )
+      expect(permutation_generator).to receive(:all_possible_tag_hashes)
+
+      list_creator.call
+    end
+
+    it "calls the email-alert-api once for each permutation" do
+      allow(permutation_generator).to receive(:all_possible_tag_hashes).and_return(
+        [
+          {"format" => ["finder-slug"], "zone" => ["industrial"]},
+          {"format" => ["finder-slug"], "zone" => ["commercial"]},
+          {"format" => ["finder-slug"], "zone" => ["industrial", "commercial"]},
+        ]
+      )
+
+      {
+        "Test Format reports with zone industrial" => ["industrial"],
+        "Test Format reports with zone commercial" => ["commercial"],
+        "Test Format reports with zone industrial or commercial" => ["industrial", "commercial"],
+      }.each_pair do |title, zones|
+        expect(email_alert_api_client).to receive(:find_or_create_subscriber_list).with(
+          {
+            "title" => title,
+            "tags" => {
+              "format" => ["finder-slug"],
+              "zone" => zones,
+            }
+          }
+        )
+      end
+
+      list_creator.call
+    end
+  end
+
+  context "without signup choices" do
+    let(:metadata) { JSON.parse(File.read('spec/fixtures/sample_metadata.json')) }
+    it "calls the email-alert-api once" do
+      expect(email_alert_api_client).to receive(:find_or_create_subscriber_list).with(
+        {
+          "title" => "Test Format reports",
+          "tags" => {
+            "format" => ["finder-slug"]
+          }
+        }
+      )
+
+      list_creator.call
+    end
+  end
+end

--- a/spec/lib/email_list_permutation_generator_spec.rb
+++ b/spec/lib/email_list_permutation_generator_spec.rb
@@ -1,0 +1,39 @@
+require "email_list_permutation_generator"
+require "spec_helper"
+
+describe EmailListPermutationGenerator do
+  let(:metadata) { JSON.parse(File.read('spec/fixtures/sample_metadata_with_signup_choices.json')) }
+  let(:choices_hash) { metadata["email_signup_choice"] }
+  let(:finder_slug) { metadata["slug"] }
+
+  subject(:creator) {
+    EmailListPermutationGenerator.new(
+      finder_slug,
+      choices_hash,
+    )
+  }
+
+  describe "#each_combination_of" do
+    it "correctly identifies array combinations" do
+      expect(creator.send(:each_combination_of, choices_hash["choices"])).to eq([
+        ["industrial"],
+        ["commercial"],
+        ["industrial", "commercial"],
+      ])
+    end
+  end
+
+  describe "#all_possible_tag_hashes" do
+    let(:required_tags) {
+      [
+        {"format" => [finder_slug], "zone" => ["industrial"]},
+        {"format" => [finder_slug], "zone" => ["commercial"]},
+        {"format" => [finder_slug], "zone" => ["industrial", "commercial"]},
+      ]
+    }
+
+    it "returns the correct tag hashes" do
+      expect(creator.all_possible_tag_hashes).to eq(required_tags)
+    end
+  end
+end


### PR DESCRIPTION
We need to provide the ability for users to sign up for a format, with filters based on a single field.

Adds a rake task to pre-create all the necessary topics for each combination of options. For formats with no options, it will create a single list for the entire format.

Also pushes the necessary options to the content store so that finder front end will be able to construct the checkboxes.
