### PR TITLE
Remove mistakenly committed extra details hashes

### DIFF
--- a/presenters/content_item_presenter.rb
+++ b/presenters/content_item_presenter.rb
@@ -9,12 +9,8 @@ class ContentItemPresenter < Struct.new(:metadata)
     Time.new.utc.iso8601
   end
 
-  # Put this into the details hash in the content store to let finder-frontendd render the checkboxes.
   def details
-    {
-      tag_key: "alert_type",
-      tags: ["devices", "drugs"],
-    }
+    {}
   end
 
   def rendering_app

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -23,10 +23,6 @@ class FinderContentItemPresenter < ContentItemPresenter
     metadata.fetch("related", [])
   end
 
-  def details
-    {}
-  end
-
   def routes
     [
       {


### PR DESCRIPTION
ContentItemPresenter was modified by mistake during discussion of how we should
implement this feature.

FinderContentItemPresenter was modified before realising that it inherits from
ContentItemPresenter.
