### PR TITLE
Add copy for metadata choices to drug-device-alerts

### DIFF
--- a/lib/email_list_permutation_generator.rb
+++ b/lib/email_list_permutation_generator.rb
@@ -6,13 +6,21 @@ class EmailListPermutationGenerator
   end
 
   def all_possible_tag_hashes
-    each_combination_of(choices_hash["choices"]).map do |combination|
-      {"format" => [format], choices_hash["key"] => combination}
+    each_combination_of(available_choices).map do |combination|
+      {"format" => [format], choice_key => combination}
     end
   end
 
 private
   attr_reader :format, :choices_hash
+
+  def available_choices
+    choices_hash["choices"].map { |entry| entry["key"] }
+  end
+
+  def choice_key
+    choices_hash["key"]
+  end
 
   # Creates a powerset for every possible combination of a set of options
   def each_combination_of(value)

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -7,8 +7,18 @@
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
   "email_signup_choice": {
-    "choices": ["drug", "device"],
     "key": "alert_type",
-    "key_name": "alert type"
+    "choices": [
+      {
+        "key": "device",
+        "name": "Medical device alerts",
+        "body": "information published by the MHRA about defective medical devices."
+      },
+      {
+        "key": "drug",
+        "name": "Drug alerts",
+        "body": "information published by the MHRA about defective medicines."
+      }
+    ]
   }
 }

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -1,6 +1,6 @@
 class FinderSignupContentItemPresenter < ContentItemPresenter
   def title
-    "#{metadata["name"]} email alert subscription"
+    metadata["name"]
   end
 
   def content_id

--- a/spec/fixtures/sample_metadata_with_signup_choices.json
+++ b/spec/fixtures/sample_metadata_with_signup_choices.json
@@ -7,7 +7,18 @@
   "organisations": ["241f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["606be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
   "email_signup_choice": {
-    "choices": ["industrial", "commercial"],
+    "choices": [
+      {
+        "key": "industrial",
+        "name": "Industrial zones",
+        "body": "information published by City about industrial zones"
+      },
+      {
+        "key": "commercial",
+        "name": "Commercial zones",
+        "body": "information published by City about commercial zones"
+      }
+    ],
     "key_name": "zone",
     "key": "zone"
   }

--- a/spec/lib/email_list_permutation_generator_spec.rb
+++ b/spec/lib/email_list_permutation_generator_spec.rb
@@ -14,8 +14,10 @@ describe EmailListPermutationGenerator do
   }
 
   describe "#each_combination_of" do
+    let(:available_choices) { choices_hash["choices"].map { |entry| entry["key"] } }
+
     it "correctly identifies array combinations" do
-      expect(creator.send(:each_combination_of, choices_hash["choices"])).to eq([
+      expect(creator.send(:each_combination_of, available_choices)).to eq([
         ["industrial"],
         ["commercial"],
         ["industrial", "commercial"],


### PR DESCRIPTION
Each checkbox/choice for an email signup needs associated copy, according to the prototype here: http://govuk-prototyping.herokuapp.com/mhra/drug_alerts.html

Adding this here makes the publishing_api:publish rake task push this to the content item for the signup page. meaning we can access it in finder-frontend.
