### PR TITLE
Increase timeout when using the email alert API to create lists

### DIFF
--- a/lib/email_list_creator.rb
+++ b/lib/email_list_creator.rb
@@ -52,7 +52,7 @@ private
   end
 
   def api_client
-    @api_client ||= api_client_class.new(Plek.current.find("email-alert-api"))
+    @api_client ||= api_client_class.new(Plek.current.find("email-alert-api"), {timeout: 30})
   end
 
   def email_signup_choice


### PR DESCRIPTION
This can take longer than the default timeout resulting in the rake task failing. If we up it to 30 we don't get timeout errors.
