### PR TITLE
Use format instead of slug for email lists

### DIFF
--- a/lib/email_list_creator.rb
+++ b/lib/email_list_creator.rb
@@ -27,7 +27,7 @@ class EmailListCreator
         {
           "title" => metadata["name"],
           "tags" => {
-            "format" => [metadata["slug"]],
+            "format" => [metadata["format"]],
           }
         }
       )
@@ -46,7 +46,7 @@ private
 
   def permutation_generator
     @generator ||= permutation_generator_class.new(
-      metadata["slug"],
+      metadata["format"],
       email_signup_choice,
     )
   end

--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -1,6 +1,7 @@
 {
   "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
   "slug": "aaib-reports",
+  "format": "aaib_report",
   "name": "Air Accidents Investigation Branch reports",
   "beta": true,
   "signup_content_id": "1ad5918c-19ff-4431-b20b-1bab890cd84b",

--- a/metadata/cma-cases.json
+++ b/metadata/cma-cases.json
@@ -1,6 +1,7 @@
 {
   "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
   "slug": "cma-cases",
+  "format": "cma_case",
   "name": "Competition and Markets Authority cases",
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -1,6 +1,7 @@
 {
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
   "slug": "drug-device-alerts",
+  "format": "medical_safety_alert",
   "name": "Alerts and recalls for drugs and medical devices",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -1,6 +1,7 @@
 {
   "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
   "slug": "drug-safety-update",
+  "format": "drug_safety_update",
   "name": "Drug safety update",
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -1,6 +1,7 @@
 {
   "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
   "slug": "international-development-funding",
+  "format": "international_development_fund",
   "name": "International development funding",
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",

--- a/metadata/maib-reports.json
+++ b/metadata/maib-reports.json
@@ -1,6 +1,7 @@
 {
   "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
   "slug": "maib-reports",
+  "format": "maib_report",
   "name": "Marine Accident Investigation Branch reports",
   "beta": true,
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",

--- a/metadata/raib-reports.json
+++ b/metadata/raib-reports.json
@@ -1,6 +1,7 @@
 {
   "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
   "slug": "raib-reports",
+  "format": "raib_report",
   "name": "Rail Accident Investigation Branch reports",
   "beta": true,
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",

--- a/spec/fixtures/sample_metadata.json
+++ b/spec/fixtures/sample_metadata.json
@@ -1,6 +1,7 @@
 {
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32758edaa3",
   "slug": "finder-slug",
+  "format": "finder_format",
   "name": "Test Format reports",
   "signup_content_id": "a796ca43-051b-4960-9c99-f41bb8ef2266",
   "signup_copy": "Signup copy info",

--- a/spec/fixtures/sample_metadata_with_signup_choices.json
+++ b/spec/fixtures/sample_metadata_with_signup_choices.json
@@ -1,6 +1,7 @@
 {
   "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32758edaa3",
   "slug": "finder-slug",
+  "format": "finder_format",
   "name": "Test Format reports",
   "signup_content_id": "a796ca43-051b-4960-9c99-f41bb8ef2266",
   "signup_copy": "Signup copy info",

--- a/spec/lib/email_list_creator_spec.rb
+++ b/spec/lib/email_list_creator_spec.rb
@@ -21,7 +21,7 @@ describe EmailListCreator do
 
     it "requests the possible permutations" do
       expect(permutation_generator_class).to receive(:new).with(
-        metadata["slug"],
+        metadata["format"],
         metadata["email_signup_choice"],
       )
       expect(permutation_generator).to receive(:all_possible_tag_hashes)
@@ -32,9 +32,9 @@ describe EmailListCreator do
     it "calls the email-alert-api once for each permutation" do
       allow(permutation_generator).to receive(:all_possible_tag_hashes).and_return(
         [
-          {"format" => ["finder-slug"], "zone" => ["industrial"]},
-          {"format" => ["finder-slug"], "zone" => ["commercial"]},
-          {"format" => ["finder-slug"], "zone" => ["industrial", "commercial"]},
+          {"format" => ["finder_format"], "zone" => ["industrial"]},
+          {"format" => ["finder_format"], "zone" => ["commercial"]},
+          {"format" => ["finder_format"], "zone" => ["industrial", "commercial"]},
         ]
       )
 
@@ -47,7 +47,7 @@ describe EmailListCreator do
           {
             "title" => title,
             "tags" => {
-              "format" => ["finder-slug"],
+              "format" => ["finder_format"],
               "zone" => zones,
             }
           }
@@ -65,7 +65,7 @@ describe EmailListCreator do
         {
           "title" => "Test Format reports",
           "tags" => {
-            "format" => ["finder-slug"]
+            "format" => ["finder_format"]
           }
         }
       )


### PR DESCRIPTION
Previously we were using the finder’s slug to set the format of an
email subscription list. This was incorrect as there is differences
between the slugs and formats. (underscores/hyphens, plural/singular
and in the case of drug safety updates completely different)

This commit adds the formats to the metadata json files, and updated
the email list creator to use them instead of slugs.
