### PR TITLE
Make alert types plural

### DIFF
--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -11,12 +11,12 @@
     "key": "alert_type",
     "choices": [
       {
-        "key": "device",
+        "key": "devices",
         "name": "Medical device alerts",
         "body": "information published by the MHRA about defective medical devices."
       },
       {
-        "key": "drug",
+        "key": "drugs",
         "name": "Drug alerts",
         "body": "information published by the MHRA about defective medicines."
       }


### PR DESCRIPTION
Similar to 5a107b7373cdc4e8fdf923b62b21d71027098016, there was a
mismatch between specialist publisher and what we specify here. Alert
types are plural, so update it here.
