### PR TITLE
Remove placeholder text

### DIFF
--- a/schemas/drug-device-alerts.json
+++ b/schemas/drug-device-alerts.json
@@ -1,7 +1,6 @@
 {
   "slug": "drug-device-alerts",
   "document_noun": "alert",
-  "keyword_search_placeholder": "eg drug or device name",
   "facets": [
     {
       "key": "alert_type",

--- a/schemas/drug-safety-update.json
+++ b/schemas/drug-safety-update.json
@@ -1,7 +1,6 @@
 {
   "slug": "drug-safety-update",
   "document_noun": "update",
-  "keyword_search_placeholder": "eg drug name",
   "facets": [
     {
       "key": "therapeutic_area",


### PR DESCRIPTION
in conjunction with this PR: https://github.com/alphagov/finder-frontend/pull/123#issuecomment-63473247
We can remove these form here as we're no longer displaying placeholder text on finder-frontend keyword search as it was confusing to users.
