### PR TITLE
Send Facets to the ContentStore

### DIFF
--- a/lib/publishing_api_publisher.rb
+++ b/lib/publishing_api_publisher.rb
@@ -4,24 +4,25 @@ require "presenters/finder_content_item_presenter"
 require "presenters/finder_signup_content_item_presenter"
 
 class PublishingApiPublisher
-  def initialize(schemae)
+  def initialize(metadata, schemae)
+    @metadata = metadata
     @schemae = schemae
   end
 
   def call
-    schemae.each do |metadata|
-      export_finder(metadata)
+    metadata.zip(schemae).map { |metadata, schema|
+      export_finder(metadata, schema)
       export_signup(metadata) if metadata.has_key?("signup_content_id")
-    end
+    }
   end
 
 private
-  attr_reader :schemae
+  attr_reader :schemae, :metadata
 
-  def export_finder(metadata)
-    attrs = exportable_attributes(FinderContentItemPresenter.new(metadata))
+  def export_finder(metadata, schema)
+    attrs = exportable_attributes(FinderContentItemPresenter.new(metadata, schema))
     if metadata.has_key?("signup_content_id")
-      attrs["links"].merge!( { "finder_email_signup" => [metadata["signup_content_id"]] })
+      attrs["links"].merge!( { "email_alert_signup" => [metadata["signup_content_id"]] })
     end
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -10,6 +10,10 @@ namespace :publishing_api do
       MultiJson.load(File.read(file_path))
     end
 
-    PublishingApiPublisher.new(metadata).call
+    schemae = Dir.glob("schemas/**/*.json").map do |file_path|
+      MultiJson.load(File.read(file_path))
+    end
+
+    PublishingApiPublisher.new(metadata, schemae).call
   end
 end

--- a/presenters/content_item_presenter.rb
+++ b/presenters/content_item_presenter.rb
@@ -1,16 +1,12 @@
 require "time"
 
-class ContentItemPresenter < Struct.new(:metadata)
+class ContentItemPresenter < Struct.new(:metadata, :schema)
   def need_ids
     []
   end
 
   def public_updated_at
     Time.new.utc.iso8601
-  end
-
-  def details
-    {}
   end
 
   def rendering_app

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -18,6 +18,9 @@ class FinderContentItemPresenter < ContentItemPresenter
   def details
     {
       beta: metadata.fetch("beta", false),
+      document_noun: schema["document_noun"],
+      document_type: metadata["format"],
+      facets: schema["facets"],
     }
   end
 

--- a/spec/unit/publishing_api_publisher_spec.rb
+++ b/spec/unit/publishing_api_publisher_spec.rb
@@ -10,13 +10,18 @@ describe PublishingApiPublisher do
         {"slug" => "second-finder", "name" => "second finder"},
       ]
 
+      schemae = [
+        {"slug" => "first-finder", "facets" => ["a facet", "another facet"] },
+        {"slug" => "second-finder", "facets" => ["a facet", "another facet"] },
+      ]
+
       expect(GdsApi::PublishingApi).to receive(:new)
         .with(Plek.new.find("publishing-api"))
         .and_return(publishing_api)
 
       expect(publishing_api).to receive(:put_content_item).twice
 
-      PublishingApiPublisher.new(metadata).call
+      PublishingApiPublisher.new(metadata, schemae).call
     end
   end
 end


### PR DESCRIPTION
This commit includes the work needed to remove the call to Finder API from Finder Frontend. We do this by adding the facets, document_type and document_noun to the FinderContentItemPresenter.
