### PR TITLE
Beta banner and signup link for dfid

### DIFF
--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -3,6 +3,7 @@
   "slug": "international-development-funding",
   "format": "international_development_fund",
   "name": "International development funding",
+  "signup_beta": true,
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -6,5 +6,6 @@
   "signup_beta": true,
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
+  "signup_enabled": true,
   "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
 }

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -20,6 +20,7 @@ class FinderContentItemPresenter < ContentItemPresenter
       beta: metadata.fetch("beta", false),
       document_noun: schema["document_noun"],
       document_type: metadata["format"],
+      email_signup_enabled: metadata.fetch("signup_enabled", false),
       facets: schema["facets"],
     }
   end

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -34,6 +34,7 @@ class FinderSignupContentItemPresenter < ContentItemPresenter
 
   def details
     {
+      "beta" => metadata.fetch("signup_beta", false),
       "email_signup_choice" => metadata["email_signup_choice"],
     }
   end


### PR DESCRIPTION
As we allow Users to sign up for email alerts we want to explain the beta status of the signup pages and we want the pages to be visible but not the link so we can test them.

This PR adds a beta flag for the signup pages starting with the International Development Fund Finder. It also adds an enabled flag which we will use to show or hide the link in the view and shows this for the IDF Finder.
