### PR TITLE
Add email choices to finders

### DIFF
--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -12,23 +12,28 @@
     "choices": [
       {
         "key": "commercial-fixed-wing",
-        "name": "Commercial - fixed wing"
+        "name": "Commercial - fixed wing",
+        "prechecked": false
       },
       {
         "key": "commercial-rotorcraft",
-        "name": "Commercial - rotorcraft"
+        "name": "Commercial - rotorcraft",
+        "prechecked": false
       },
       {
         "key": "general-aviation-fixed-wing",
-        "name": "General aviation - fixed wing"
+        "name": "General aviation - fixed wing",
+        "prechecked": false
       },
       {
         "key": "general-aviation-rotorcraft",
-        "name": "General aviation - rotorcraft"
+        "name": "General aviation - rotorcraft",
+        "prechecked": false
       },
       {
         "key": "sport-aviation-and-balloons",
-        "name": "Sport aviation and balloons"
+        "name": "Sport aviation and balloons",
+        "prechecked": false
       }
     ]
   }

--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -6,5 +6,30 @@
   "beta": true,
   "signup_content_id": "1ad5918c-19ff-4431-b20b-1bab890cd84b",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
-  "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"]
+  "organisations": ["38eb5d8f-2d89-480c-8655-e2e7ac23f8f4"],
+  "email_signup_choice": {
+    "key": "aircraft_category",
+    "choices": [
+      {
+        "key": "commercial-fixed-wing",
+        "name": "Commercial - fixed wing"
+      },
+      {
+        "key": "commercial-rotorcraft",
+        "name": "Commercial - rotorcraft"
+      },
+      {
+        "key": "general-aviation-fixed-wing",
+        "name": "General aviation - fixed wing"
+      },
+      {
+        "key": "general-aviation-rotorcraft",
+        "name": "General aviation - rotorcraft"
+      },
+      {
+        "key": "sport-aviation-and-balloons",
+        "name": "Sport aviation and balloons"
+      }
+    ]
+  }
 }

--- a/metadata/cma-cases.json
+++ b/metadata/cma-cases.json
@@ -11,31 +11,38 @@
     "choices": [
       {
         "key": "ca98-and-civil-cartels",
-        "name": "CA98 and civil cartels"
+        "name": "CA98 and civil cartels",
+        "prechecked": false
       },
       {
         "key": "criminal-cartels",
-        "name": "Criminal cartels"
+        "name": "Criminal cartels",
+        "prechecked": false
       },
       {
         "key": "markets",
-        "name": "Markets"
+        "name": "Markets",
+        "prechecked": false
       },
       {
         "key": "mergers",
-        "name": "Mergers"
+        "name": "Mergers",
+        "prechecked": false
       },
       {
         "key": "consumer-enforcement",
-        "name": "Consumer enforcement"
+        "name": "Consumer enforcement",
+        "prechecked": false
       },
       {
         "key": "regulatory-references-and-appeals",
-        "name": "Regulatory references and appeals"
+        "name": "Regulatory references and appeals",
+        "prechecked": false
       },
       {
         "key": "review-of-orders-and-undertakings",
-        "name": "Reviews of orders and undertakings"
+        "name": "Reviews of orders and undertakings",
+        "prechecked": false
       }
     ]
   }

--- a/metadata/cma-cases.json
+++ b/metadata/cma-cases.json
@@ -5,5 +5,38 @@
   "name": "Competition and Markets Authority cases",
   "signup_content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "signup_copy": "You'll get an email each time a case is updated or a new case is published.",
-  "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"]
+  "organisations": ["957eb4ec-089b-4f71-ba2a-dc69ac8919ea"],
+  "email_signup_choice": {
+    "key": "case_type",
+    "choices": [
+      {
+        "key": "ca98-and-civil-cartels",
+        "name": "CA98 and civil cartels"
+      },
+      {
+        "key": "criminal-cartels",
+        "name": "Criminal cartels"
+      },
+      {
+        "key": "markets",
+        "name": "Markets"
+      },
+      {
+        "key": "mergers",
+        "name": "Mergers"
+      },
+      {
+        "key": "consumer-enforcement",
+        "name": "Consumer enforcement"
+      },
+      {
+        "key": "regulatory-references-and-appeals",
+        "name": "Regulatory references and appeals"
+      },
+      {
+        "key": "review-of-orders-and-undertakings",
+        "name": "Reviews of orders and undertakings"
+      }
+    ]
+  }
 }

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -14,12 +14,14 @@
       {
         "key": "devices",
         "name": "Medical device alerts",
-        "body": "information published by the MHRA about defective medical devices."
+        "body": "information published by the MHRA about defective medical devices.",
+        "prechecked": true
       },
       {
         "key": "drugs",
         "name": "Drug alerts",
-        "body": "information published by the MHRA about defective medicines."
+        "body": "information published by the MHRA about defective medicines.",
+        "prechecked": true
       }
     ]
   }

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -7,5 +7,70 @@
   "signup_content_id": "f1a4e5b2-c8b3-40f2-acde-75061a45184d",
   "signup_copy": "You'll get an email each time a fund is updated or a new fund is published.",
   "signup_enabled": true,
-  "organisations": ["db994552-7644-404d-a770-a2fe659c661f"]
+  "organisations": ["db994552-7644-404d-a770-a2fe659c661f"],
+  "email_signup_choice": {
+    "key": "development_sector",
+    "choices": [
+      {
+        "key": "agriculture",
+        "name": "Agriculture"
+      },
+      {
+        "key": "climate-change",
+        "name": "Climate change"
+      },
+      {
+        "key": "disabilities",
+        "name": "Disabilities"
+      },
+      {
+        "key": "education",
+        "name": "Education"
+      },
+      {
+        "key": "empowerment-and-accountability",
+        "name": "Empowerment and accountability"
+      },
+      {
+        "key": "environment",
+        "name": "Environment"
+      },
+      {
+        "key": "girls-and-women",
+        "name": "Girls and women"
+      },
+      {
+        "key": "health",
+        "name": "Health"
+      },
+      {
+        "key": "humanitarian-emergencies-disasters",
+        "name": "Humanitarian emergencies/disasters"
+      },
+      {
+        "key": "livelihoods",
+        "name": "Livelihoods"
+      },
+      {
+        "key": "peace-and-access-to-justice",
+        "name": "Peace and access to justice"
+      },
+      {
+        "key": "private-sector-business",
+        "name": "Private sector/business"
+      },
+      {
+        "key": "technology",
+        "name": "Technology"
+      },
+      {
+        "key": "trade",
+        "name": "Trade"
+      },
+      {
+        "key": "water-and-sanitation",
+        "name": "Water and sanitation"
+      }
+    ]
+  }
 }

--- a/metadata/international-development-funding.json
+++ b/metadata/international-development-funding.json
@@ -13,63 +13,78 @@
     "choices": [
       {
         "key": "agriculture",
-        "name": "Agriculture"
+        "name": "Agriculture",
+        "prechecked": false
       },
       {
         "key": "climate-change",
-        "name": "Climate change"
+        "name": "Climate change",
+        "prechecked": false
       },
       {
         "key": "disabilities",
-        "name": "Disabilities"
+        "name": "Disabilities",
+        "prechecked": false
       },
       {
         "key": "education",
-        "name": "Education"
+        "name": "Education",
+        "prechecked": false
       },
       {
         "key": "empowerment-and-accountability",
-        "name": "Empowerment and accountability"
+        "name": "Empowerment and accountability",
+        "prechecked": false
       },
       {
         "key": "environment",
-        "name": "Environment"
+        "name": "Environment",
+        "prechecked": false
       },
       {
         "key": "girls-and-women",
-        "name": "Girls and women"
+        "name": "Girls and women",
+        "prechecked": false
       },
       {
         "key": "health",
-        "name": "Health"
+        "name": "Health",
+        "prechecked": false
       },
       {
         "key": "humanitarian-emergencies-disasters",
-        "name": "Humanitarian emergencies/disasters"
+        "name": "Humanitarian emergencies/disasters",
+        "prechecked": false
       },
       {
         "key": "livelihoods",
-        "name": "Livelihoods"
+        "name": "Livelihoods",
+        "prechecked": false
       },
       {
         "key": "peace-and-access-to-justice",
-        "name": "Peace and access to justice"
+        "name": "Peace and access to justice",
+        "prechecked": false
       },
       {
         "key": "private-sector-business",
-        "name": "Private sector/business"
+        "name": "Private sector/business",
+        "prechecked": false
       },
       {
         "key": "technology",
-        "name": "Technology"
+        "name": "Technology",
+        "prechecked": false
       },
       {
         "key": "trade",
-        "name": "Trade"
+        "name": "Trade",
+        "prechecked": false
       },
       {
         "key": "water-and-sanitation",
-        "name": "Water and sanitation"
+        "name": "Water and sanitation",
+        "prechecked": false
       }
     ]
   }

--- a/metadata/maib-reports.json
+++ b/metadata/maib-reports.json
@@ -6,5 +6,30 @@
   "beta": true,
   "signup_content_id": "56cb57e2-7e7f-4f67-b2f6-39c9a55385dc",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
-  "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"]
+  "organisations": ["9c66b9a3-1e6a-48e8-974d-2a5635f84679"],
+  "email_signup_choice": {
+    "key": "vessel_type",
+    "choices": [
+      {
+        "key": "merchant-vessel-100-gross-tons-or-over",
+        "name": "Merchant vessel 100 gross tons or over"
+      },
+      {
+        "key": "merchant-vessel-under-100-gross-tons",
+        "name": "Merchant vessel under 100 gross tons"
+      },
+      {
+        "key": "fishing-vessel",
+        "name": "Fishing vessel"
+      },
+      {
+        "key": "recreational-craft-sail",
+        "name": "Recreational craft - sail"
+      },
+      {
+        "key": "recreational-craft-power",
+        "name": "Recreational craft - power"
+      }
+    ]
+  }
 }

--- a/metadata/maib-reports.json
+++ b/metadata/maib-reports.json
@@ -12,23 +12,28 @@
     "choices": [
       {
         "key": "merchant-vessel-100-gross-tons-or-over",
-        "name": "Merchant vessel 100 gross tons or over"
+        "name": "Merchant vessel 100 gross tons or over",
+        "prechecked": false
       },
       {
         "key": "merchant-vessel-under-100-gross-tons",
-        "name": "Merchant vessel under 100 gross tons"
+        "name": "Merchant vessel under 100 gross tons",
+        "prechecked": false
       },
       {
         "key": "fishing-vessel",
-        "name": "Fishing vessel"
+        "name": "Fishing vessel",
+        "prechecked": false
       },
       {
         "key": "recreational-craft-sail",
-        "name": "Recreational craft - sail"
+        "name": "Recreational craft - sail",
+        "prechecked": false
       },
       {
         "key": "recreational-craft-power",
-        "name": "Recreational craft - power"
+        "name": "Recreational craft - power",
+        "prechecked": false
       }
     ]
   }

--- a/metadata/raib-reports.json
+++ b/metadata/raib-reports.json
@@ -12,19 +12,23 @@
     "choices": [
       {
         "key": "heavy-rail",
-        "name": "Heavy rail"
+        "name": "Heavy rail",
+        "prechecked": false
       },
       {
         "key": "light-rail",
-        "name": "Light rail"
+        "name": "Light rail",
+        "prechecked": false
       },
       {
         "key": "metros",
-        "name": "Metros"
+        "name": "Metros",
+        "prechecked": false
       },
       {
         "key": "heritage-railways",
-        "name": "Heritage railways"
+        "name": "Heritage railways",
+        "prechecked": false
       }
     ]
   }

--- a/metadata/raib-reports.json
+++ b/metadata/raib-reports.json
@@ -6,5 +6,26 @@
   "beta": true,
   "signup_content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "signup_copy": "You'll get an email each time a report is updated or a new report is published.",
-  "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"]
+  "organisations": ["013872d8-8bbb-4e80-9b79-45c7c5cf9177"],
+  "email_signup_choice": {
+    "key": "railway_type",
+    "choices": [
+      {
+        "key": "heavy-rail",
+        "name": "Heavy rail"
+      },
+      {
+        "key": "light-rail",
+        "name": "Light rail"
+      },
+      {
+        "key": "metros",
+        "name": "Metros"
+      },
+      {
+        "key": "heritage-railways",
+        "name": "Heritage railways"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Ticket: https://trello.com/c/DzJdcftL/431-checkbox-email-signup-for-other-finders-3

This pull request adds new filtering options to finder-api metadata files. This is used by finder-frontend to generate the checkboxes on email signup pages.

We have also added an extra field to the metadata in order to decide wether the choice should be preselected by default on page load. This will be used by finder frontend to display preselected values
