### PR TITLE
Different beta message for MHRA Finders

### DIFF
--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -4,6 +4,7 @@
   "format": "medical_safety_alert",
   "name": "Alerts and recalls for drugs and medical devices",
   "beta": true,
+  "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/Safetywarningsalertsandrecalls/index.htm'>the MHRA website</a> is the main source for drug alerts and medical device alerts.",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],

--- a/metadata/drug-safety-update.json
+++ b/metadata/drug-safety-update.json
@@ -4,6 +4,7 @@
   "format": "drug_safety_update",
   "name": "Drug safety update",
   "beta": true,
+  "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/DrugSafetyUpdate/index.htm'>the MHRA website</a> is the official home of the Drug Safety Update.",
   "signup_content_id": "ccf11f55-02ee-48ec-b71c-7e3fe78b3a17",
   "signup_copy": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],

--- a/presenters/finder_content_item_presenter.rb
+++ b/presenters/finder_content_item_presenter.rb
@@ -18,6 +18,7 @@ class FinderContentItemPresenter < ContentItemPresenter
   def details
     {
       beta: metadata.fetch("beta", false),
+      beta_message: metadata.fetch("beta_message", nil),
       document_noun: schema["document_noun"],
       document_type: metadata["format"],
       email_signup_enabled: metadata.fetch("signup_enabled", false),


### PR DESCRIPTION
As we want to specify why the Finders are Beta, the default message doesn't really work. This commit adds the option to pass it to the content store along with the actual options for the 2 Finders.
