### PR TITLE
New names for email lists generated on govdelivery

### DIFF
--- a/lib/email_list_creator.rb
+++ b/lib/email_list_creator.rb
@@ -38,10 +38,16 @@ private
   attr_reader :metadata, :permutation_generator_class, :api_client_class
 
   def list_title_for(tag_hash)
-    key = email_signup_choice["key"]
-    key_name = email_signup_choice["key_name"]
-    selected_options = tag_hash[key].join(" or ")
-    "#{metadata["name"]} with #{key_name} #{selected_options}"
+    keys = tag_hash[email_signup_choice["key"]]
+    keys.collect {|key| name_for_key(key)}.join(" and ")
+  end
+
+  def name_for_key(key)
+    find_choice_by_key(key)["name"]
+  end
+
+  def find_choice_by_key(key)
+    email_signup_choice["choices"].select {|choice| choice["key"] == key}[0]
   end
 
   def permutation_generator

--- a/spec/lib/email_list_creator_spec.rb
+++ b/spec/lib/email_list_creator_spec.rb
@@ -39,9 +39,9 @@ describe EmailListCreator do
       )
 
       {
-        "Test Format reports with zone industrial" => ["industrial"],
-        "Test Format reports with zone commercial" => ["commercial"],
-        "Test Format reports with zone industrial or commercial" => ["industrial", "commercial"],
+        "Industrial zones" => ["industrial"],
+        "Commercial zones" => ["commercial"],
+        "Industrial zones and Commercial zones" => ["industrial", "commercial"],
       }.each_pair do |title, zones|
         expect(email_alert_api_client).to receive(:find_or_create_subscriber_list).with(
           {


### PR DESCRIPTION
Previously we had slightly convoluted names of email lists on gov
delivery. e.g. “Alerts and recalls for drugs and medical devices with
devices or drugs”

This simplifies this, e.g. “Drug Alerts and Medical Alerts”
