### PR TITLE
Different title for signup pages

### DIFF
--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -6,6 +6,7 @@
   "beta": true,
   "beta_message": "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/Safetywarningsalertsandrecalls/index.htm'>the MHRA website</a> is the main source for drug alerts and medical device alerts.",
   "signup_content_id": "a796ca43-021b-4960-9c99-f41bb8ef2266",
+  "signup_title": "Drug alerts and medical device alerts",
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -1,6 +1,6 @@
 class FinderSignupContentItemPresenter < ContentItemPresenter
   def title
-    metadata["name"]
+    metadata.fetch("signup_title", metadata["name"])
   end
 
   def content_id


### PR DESCRIPTION
If a different title for signup pages is present in the metadata hash use that instead. This PR also adds a different title for the Drug & Device Alerts finder. [Ticket](https://trello.com/c/5eGxG3oI/410-email-subscriptions-custom-sign-up-title-3).
