### PR TITLE
Re-add filter key

### DIFF
--- a/metadata/aaib-reports.json
+++ b/metadata/aaib-reports.json
@@ -11,6 +11,7 @@
     "singular": "Air Accidents Investigation Branch (AAIB) reports with the following aircraft category: ",
     "plural": "Air Accidents Investigation Branch (AAIB) reports with the following aircraft categories: "
   },
+  "email_filter_by": "aircraft_category",
   "email_signup_choice": [
     {
       "key": "commercial-fixed-wing",

--- a/metadata/drug-device-alerts.json
+++ b/metadata/drug-device-alerts.json
@@ -10,6 +10,7 @@
   "signup_copy": "You'll get an email each time an alert is updated or a new alert is published.",
   "organisations": ["240f72bd-9a4d-4f39-94d9-77235cadde8e"],
   "related": ["602be505-4cf4-4f8c-8bfc-7bc4b63a7f47"],
+  "email_filter_by": "alert_type",
   "email_signup_choice": [
     {
       "key": "devices",

--- a/presenters/finder_signup_content_item_presenter.rb
+++ b/presenters/finder_signup_content_item_presenter.rb
@@ -36,6 +36,7 @@ class FinderSignupContentItemPresenter < ContentItemPresenter
     {
       "beta" => metadata.fetch("signup_beta", false),
       "email_signup_choice" => metadata.fetch("email_signup_choice", []),
+      "email_filter_by" => metadata.fetch("email_filter_by", nil),
       "subscription_list_title_prefix" => metadata.fetch("subscription_list_title_prefix", {})
     }
   end


### PR DESCRIPTION
Tom was right, I was wrong. We need this key to match up with
Specialist Publisher’s tagging.
